### PR TITLE
Fix InMemory stream Version not advancing on append

### DIFF
--- a/src/Papst.EventStore.InMemory/InMemoryEventStream.cs
+++ b/src/Papst.EventStore.InMemory/InMemoryEventStream.cs
@@ -11,6 +11,7 @@ namespace Papst.EventStore.InMemory;
 internal class InMemoryEventStream : IEventStream
 {
   private readonly List<EventStreamDocument> _events = new();
+  private readonly ulong _initialVersion;
   private readonly TimeProvider _tp;
   private readonly string _targetType;
   private readonly IEventTypeProvider _typeProvider;
@@ -25,7 +26,7 @@ internal class InMemoryEventStream : IEventStream
     IEventTypeProvider typeProvider)
   {
     StreamId = streamId;
-    Version = version;
+    _initialVersion = version;
     Created = created;
     MetaData = metaData;
     _tp = tp;
@@ -34,7 +35,7 @@ internal class InMemoryEventStream : IEventStream
   }
 
   public Guid StreamId { get; }
-  public ulong Version { get; }
+  public ulong Version => _events.Count == 0 ? _initialVersion : _events.Max(e => e.Version);
   public DateTimeOffset Created { get; }
   public ulong? LatestSnapshotVersion => _events
     .Where(e => e.DocumentType == EventStreamDocumentType.Snapshot)
@@ -136,7 +137,7 @@ internal class InMemoryTransactionalBatch(
   string targetType) : IEventStoreTransactionAppender
 {
   private readonly List<Action> _actions = [];
-    
+
   public IEventStoreTransactionAppender Add<TEvent>(Guid id, TEvent evt, EventStreamMetaData? metaData = null,
     CancellationToken cancellationToken = default) where TEvent : notnull
   {
@@ -144,7 +145,7 @@ internal class InMemoryTransactionalBatch(
     _actions.Add(() => events.Add(new EventStreamDocument()
     {
       StreamId = streamId,
-      Version = events.Max(e => e.Version) + 1,
+      Version = (events.Count == 0 ? 0UL : events.Max(e => e.Version)) + 1,
       Time = tp.GetLocalNow(),
       DataType = name,
       Data = JObject.FromObject(evt),

--- a/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStreamTests.cs
+++ b/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStreamTests.cs
@@ -38,10 +38,10 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
     {
       await stream.AppendAsync(Guid.NewGuid(), @event, cancellationToken: CancellationToken.None);
     }
-    
+
     // act
     var result = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
-    
+
     // assert
     result.Count.ShouldBe(events.Count);
     result.Select(e => e.Data.ToObject<TestEvent>())
@@ -50,5 +50,63 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
       .ToList()
       .ShouldBe(events);
   }
-  
+
+  [Theory, AutoData]
+  public async Task AppendAsync_ShouldAssignSequentialEventVersions(List<TestEvent> events, Guid streamId)
+  {
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    var stream = await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+    foreach (var @event in events)
+    {
+      await stream.AppendAsync(Guid.NewGuid(), @event, cancellationToken: CancellationToken.None);
+    }
+
+    var result = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
+
+    result.Select(e => e.Version).ShouldBe(Enumerable.Range(1, events.Count).Select(i => (ulong)i));
+  }
+
+  [Theory, AutoData]
+  public async Task AppendAsync_ShouldAdvanceStreamVersion(List<TestEvent> events, Guid streamId)
+  {
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    var stream = await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+    foreach (var @event in events)
+    {
+      await stream.AppendAsync(Guid.NewGuid(), @event, cancellationToken: CancellationToken.None);
+    }
+
+    stream.Version.ShouldBe((ulong)events.Count);
+  }
+
+  [Theory, AutoData]
+  public async Task AppendSnapshotAsync_ShouldAdvanceStreamVersion(TestEvent firstEvent, TestEvent snapshot, Guid streamId)
+  {
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    var stream = await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), firstEvent, cancellationToken: CancellationToken.None);
+    await stream.AppendSnapshotAsync(Guid.NewGuid(), snapshot, cancellationToken: CancellationToken.None);
+
+    var documents = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
+    documents.Select(d => d.Version).ShouldBe([1UL, 2UL]);
+    stream.Version.ShouldBe(2UL);
+  }
+
+  [Theory, AutoData]
+  public async Task ListAsync_FromVersionGreaterThanOne_ShouldReturnEventsAppendedAfterFirst(TestEvent first, TestEvent second, Guid streamId)
+  {
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    var stream = await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), first, cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), second, cancellationToken: CancellationToken.None);
+
+    var result = await stream.ListAsync(2, CancellationToken.None).ToListAsync(CancellationToken.None);
+
+    result.Count.ShouldBe(1);
+    result[0].Data.ToObject<TestEvent>().ShouldBe(second);
+  }
 }


### PR DESCRIPTION
## Summary

`InMemoryEventStream.Version` was a get-only property set in the constructor and never updated. `AppendAsync` writes each event with `Version + 1`, but since `Version` never moved off its initial value, every direct append produced an event at version 1 and the stream's reported tip stayed at 0.

This breaks any caller that relies on `stream.Version` reflecting the actual tip — most visibly the incremental aggregation overload `AggregateAsync(stream, target, ct)`, which reads `stream.Version` as its `targetVersion`. With a stale tip, the loop's `target.Version == targetVersion` break can fire before any newly-appended events are applied, so incremental aggregation silently no-ops after the first append.

The Cosmos implementation already keeps `Version` in sync via the `PatchItemAsync` response on each append; the issue was specific to the in-memory store.

## Fix

Derive `Version` from the events list, mirroring how `LatestSnapshotVersion` already works in the same class:

```csharp
public ulong Version => _events.Count == 0 ? _initialVersion : _events.Max(e => e.Version);
```

The constructor-supplied `version` is kept as `_initialVersion` so an empty stream still reports the seed value. `AppendAsync` and `AppendSnapshotAsync` keep their `Version = Version + 1` lines unchanged — they now read the live tip. `InMemoryTransactionalBatch` is unaffected.

## Test plan

- [x] New tests in `InMemoryEventStreamTests` pin the contract:
  - `AppendAsync` produces events at versions 1, 2, 3, …
  - `AppendAsync` advances `stream.Version`
  - `AppendSnapshotAsync` advances `stream.Version`
  - `ListAsync(2, …)` returns the second event after two appends
- [x] All existing Papst test projects green (InMemory 7, EventStore 54, CodeGeneration 20, MongoDB 10, AzureCosmos 9)
- [x] Verified against AltensoSCM's integration suite — incremental aggregation now correctly applies post-first-append events