### PR TITLE
Make InMemory event store thread-safe

### DIFF
--- a/src/Papst.EventStore.InMemory/InMemoryEventStore.cs
+++ b/src/Papst.EventStore.InMemory/InMemoryEventStore.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +9,7 @@ namespace Papst.EventStore.InMemory;
 
 public class InMemoryEventStore : IEventStore
 {
-  private readonly Dictionary<Guid, InMemoryEventStream> _streams = new();
+  private readonly ConcurrentDictionary<Guid, InMemoryEventStream> _streams = new();
   private readonly TimeProvider _timeProvider;
   private readonly IEventTypeProvider _eventTypeProvider;
 
@@ -45,11 +46,6 @@ public class InMemoryEventStore : IEventStore
     string? username,
     string? comment, Dictionary<string, string>? additionalMetaData, CancellationToken cancellationToken = default)
   {
-    if (_streams.ContainsKey(streamId))
-    {
-      throw new EventStreamAlreadyExistsException(streamId, "Stream already exists");
-    }
-
     var stream = new InMemoryEventStream(
       streamId,
       0,
@@ -66,7 +62,11 @@ public class InMemoryEventStore : IEventStore
       targetTypeName,
       _eventTypeProvider
     );
-    _streams.Add(streamId, stream);
+    if (!_streams.TryAdd(streamId, stream))
+    {
+      throw new EventStreamAlreadyExistsException(streamId, "Stream already exists");
+    }
+
     return Task.FromResult<IEventStream>(stream);
   }
 }

--- a/src/Papst.EventStore.InMemory/InMemoryEventStream.cs
+++ b/src/Papst.EventStore.InMemory/InMemoryEventStream.cs
@@ -10,6 +10,10 @@ namespace Papst.EventStore.InMemory;
 
 internal class InMemoryEventStream : IEventStream
 {
+  // Guards _events: appends can race stream reads when the store is shared
+  // across threads (e.g. an application host processing events on background
+  // threads while tests seed streams).
+  private readonly Lock _lock = new();
   private readonly List<EventStreamDocument> _events = new();
   private readonly ulong _initialVersion;
   private readonly TimeProvider _tp;
@@ -35,34 +39,66 @@ internal class InMemoryEventStream : IEventStream
   }
 
   public Guid StreamId { get; }
-  public ulong Version => _events.Count == 0 ? _initialVersion : _events.Max(e => e.Version);
+
+  public ulong Version
+  {
+    get
+    {
+      lock (_lock)
+      {
+        return VersionUnlocked;
+      }
+    }
+  }
+
+  private ulong VersionUnlocked => _events.Count == 0 ? _initialVersion : _events.Max(e => e.Version);
+
   public DateTimeOffset Created { get; }
-  public ulong? LatestSnapshotVersion => _events
-    .Where(e => e.DocumentType == EventStreamDocumentType.Snapshot)
-    .MaxBy(e => e.Version)?
-    .Version;
+
+  public ulong? LatestSnapshotVersion
+  {
+    get
+    {
+      lock (_lock)
+      {
+        return _events
+          .Where(e => e.DocumentType == EventStreamDocumentType.Snapshot)
+          .MaxBy(e => e.Version)?
+          .Version;
+      }
+    }
+  }
+
   public EventStreamMetaData MetaData { get; }
 
-  public Task<EventStreamDocument?> GetLatestSnapshot(CancellationToken cancellationToken = default) 
-    => Task.FromResult(_events.LastOrDefault(e => e.DocumentType == EventStreamDocumentType.Snapshot));
+  public Task<EventStreamDocument?> GetLatestSnapshot(CancellationToken cancellationToken = default)
+  {
+    lock (_lock)
+    {
+      return Task.FromResult(_events.LastOrDefault(e => e.DocumentType == EventStreamDocumentType.Snapshot));
+    }
+  }
 
   public Task AppendAsync<TEvent>(Guid id, TEvent evt, EventStreamMetaData? metaData = null,
     CancellationToken cancellationToken = default) where TEvent : notnull
   {
     string name = _typeProvider.ResolveType(typeof(TEvent));
-    _events.Add(new EventStreamDocument()
+    lock (_lock)
     {
-      StreamId = StreamId,
-      Version = Version + 1,
-      Time = _tp.GetLocalNow(),
-      DataType = name,
-      Data = JObject.FromObject(evt),
-      DocumentType = EventStreamDocumentType.Event,
-      MetaData = metaData ?? new EventStreamMetaData(),
-      TargetType = _targetType,
-      Id = id,
-      Name = name
-    });
+      _events.Add(new EventStreamDocument()
+      {
+        StreamId = StreamId,
+        Version = VersionUnlocked + 1,
+        Time = _tp.GetLocalNow(),
+        DataType = name,
+        Data = JObject.FromObject(evt),
+        DocumentType = EventStreamDocumentType.Event,
+        MetaData = metaData ?? new EventStreamMetaData(),
+        TargetType = _targetType,
+        Id = id,
+        Name = name
+      });
+    }
 
     return Task.CompletedTask;
   }
@@ -70,19 +106,22 @@ internal class InMemoryEventStream : IEventStream
   public Task AppendSnapshotAsync<TEntity>(Guid id, TEntity entity, EventStreamMetaData? metaData = null,
     CancellationToken cancellationToken = default) where TEntity : notnull
   {
-    _events.Add(new EventStreamDocument()
+    lock (_lock)
     {
-      StreamId = StreamId,
-      Version = Version + 1,
-      Time = _tp.GetLocalNow(),
-      DataType = _targetType,
-      Data = JObject.FromObject(entity),
-      DocumentType = EventStreamDocumentType.Snapshot,
-      MetaData = metaData ?? new EventStreamMetaData(),
-      TargetType = _targetType,
-      Id = id,
-      Name = _targetType
-    });
+      _events.Add(new EventStreamDocument()
+      {
+        StreamId = StreamId,
+        Version = VersionUnlocked + 1,
+        Time = _tp.GetLocalNow(),
+        DataType = _targetType,
+        Data = JObject.FromObject(entity),
+        DocumentType = EventStreamDocumentType.Snapshot,
+        MetaData = metaData ?? new EventStreamMetaData(),
+        TargetType = _targetType,
+        Id = id,
+        Name = _targetType
+      });
+    }
 
     return Task.CompletedTask;
   }
@@ -90,37 +129,52 @@ internal class InMemoryEventStream : IEventStream
   public Task<IEventStoreTransactionAppender> CreateTransactionalBatchAsync()
   {
     return Task.FromResult<IEventStoreTransactionAppender>(
-      new InMemoryTransactionalBatch(_events, _typeProvider, _tp, StreamId, _targetType));
+      new InMemoryTransactionalBatch(_lock, _events, _typeProvider, _tp, StreamId, _targetType));
   }
 
   public IAsyncEnumerable<EventStreamDocument> ListAsync(ulong startVersion = 0,
     CancellationToken cancellationToken = default)
   {
-    return _events.Where(evt => evt.Version >= startVersion).ToAsyncEnumerable();
+    lock (_lock)
+    {
+      return _events.Where(evt => evt.Version >= startVersion).ToList().ToAsyncEnumerable();
+    }
   }
 
   public IAsyncEnumerable<EventStreamDocument> ListAsync(ulong startVersion, ulong endVersion,
     CancellationToken cancellationToken = default)
   {
-    return _events
-      .Where(evt => evt.Version >= startVersion && evt.Version <= endVersion)
-      .ToAsyncEnumerable();
+    lock (_lock)
+    {
+      return _events
+        .Where(evt => evt.Version >= startVersion && evt.Version <= endVersion)
+        .ToList()
+        .ToAsyncEnumerable();
+    }
   }
 
   public IAsyncEnumerable<EventStreamDocument> ListDescendingAsync(ulong endVersion, ulong startVersion,
     CancellationToken cancellationToken = default)
   {
-    return _events.Where(evt => evt.Version >= startVersion && evt.Version <= endVersion)
-      .OrderByDescending(evt => evt.Version)
-      .ToAsyncEnumerable();
+    lock (_lock)
+    {
+      return _events.Where(evt => evt.Version >= startVersion && evt.Version <= endVersion)
+        .OrderByDescending(evt => evt.Version)
+        .ToList()
+        .ToAsyncEnumerable();
+    }
   }
 
   public IAsyncEnumerable<EventStreamDocument> ListDescendingAsync(ulong endVersion,
     CancellationToken cancellationToken = default)
   {
-    return _events.Where(evt => evt.Version <= endVersion)
-      .OrderByDescending(evt => evt.Version)
-      .ToAsyncEnumerable();
+    lock (_lock)
+    {
+      return _events.Where(evt => evt.Version <= endVersion)
+        .OrderByDescending(evt => evt.Version)
+        .ToList()
+        .ToAsyncEnumerable();
+    }
   }
 
   public Task UpdateStreamMetaData(EventStreamMetaData metaData, CancellationToken cancellationToken = default)
@@ -130,6 +184,7 @@ internal class InMemoryEventStream : IEventStream
 }
 
 internal class InMemoryTransactionalBatch(
+  Lock syncRoot,
   List<EventStreamDocument> events,
   IEventTypeProvider typeProvider,
   TimeProvider tp,
@@ -161,10 +216,14 @@ internal class InMemoryTransactionalBatch(
 
   public Task CommitAsync(CancellationToken cancellationToken = default)
   {
-    foreach (var action in _actions)
+    lock (syncRoot)
     {
-      action();
+      foreach (var action in _actions)
+      {
+        action();
+      }
     }
+
     return Task.CompletedTask;
   }
 }

--- a/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStoreTests.cs
+++ b/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStoreTests.cs
@@ -1,6 +1,7 @@
 using AutoFixture.Xunit2;
 using Microsoft.Extensions.DependencyInjection;
 using Papst.EventStore;
+using Papst.EventStore.Exceptions;
 using Shouldly;
 
 namespace Papst.EventsStore.InMemory.Tests.IntegrationTests;
@@ -25,6 +26,49 @@ public class InMemoryEventStoreTests : IClassFixture<InMemoryTestFixture>
     stream.StreamId.ShouldBe(streamId);
     stream.Version.ShouldBe(0UL);
   }
-  
-  
+
+  [Fact]
+  public async Task CreateAsync_ShouldCreateAllStreams_WhenCalledConcurrently()
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    var streamIds = Enumerable.Range(0, 1_000).Select(_ => Guid.NewGuid()).ToList();
+
+    // act
+    await Task.WhenAll(streamIds.Select(id =>
+      Task.Run(() => eventStore.CreateAsync(id, "", CancellationToken.None))));
+
+    // assert
+    foreach (var id in streamIds)
+    {
+      (await eventStore.GetAsync(id, CancellationToken.None)).StreamId.ShouldBe(id);
+    }
+  }
+
+  [Theory, AutoData]
+  public async Task CreateAsync_ShouldThrowAlreadyExists_WhenSameStreamCreatedConcurrently(Guid streamId)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+
+    // act
+    var results = await Task.WhenAll(Enumerable.Range(0, 64).Select(_ => Task.Run(async () =>
+    {
+      try
+      {
+        await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+        return null;
+      }
+      catch (Exception ex)
+      {
+        return ex;
+      }
+    })));
+
+    // assert
+    results.Count(r => r is null).ShouldBe(1);
+    results.Where(r => r is not null).ShouldAllBe(r => r is EventStreamAlreadyExistsException);
+  }
 }

--- a/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStreamTests.cs
+++ b/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStreamTests.cs
@@ -109,4 +109,23 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
     result.Count.ShouldBe(1);
     result[0].Data.ToObject<TestEvent>().ShouldBe(second);
   }
+
+  [Theory, AutoData]
+  public async Task AppendAsync_ShouldRetainAllEventsWithUniqueVersions_WhenAppendedConcurrently(TestEvent @event, Guid streamId)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    var stream = await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+
+    // act
+    await Task.WhenAll(Enumerable.Range(0, 500).Select(_ =>
+      Task.Run(() => stream.AppendAsync(Guid.NewGuid(), @event, cancellationToken: CancellationToken.None))));
+
+    // assert
+    stream.Version.ShouldBe(500UL);
+    var documents = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
+    documents.Count.ShouldBe(500);
+    documents.Select(d => d.Version).ShouldBeUnique();
+  }
 }


### PR DESCRIPTION
## Problem

`InMemoryEventStore` and `InMemoryEventStream` are not safe for concurrent use:

- `InMemoryEventStore.CreateAsync` does a check-then-add (`ContainsKey` + `Add`) on a plain `Dictionary` — concurrent creates corrupt the dictionary (`InvalidOperationException: Operations that change non-concurrent collections must have exclusive access…`), and once corrupted every subsequent store call fails. Two racing creates for the same id can also both succeed.
- `InMemoryEventStream.AppendAsync` computes `Version + 1` by enumerating the live `List` and then `Add`s to it — concurrent appends lose events, assign duplicate versions, or corrupt the list.
- `InMemoryTransactionalBatch.CommitAsync` appends to the same raw list unguarded.

This bites in practice when the store backs an ASP.NET Core test host (`WebApplicationFactory`): background services or notification handlers append events on thread-pool threads while the test thread seeds streams. We hit it as a flaky CI failure in a downstream project — one corruption cascaded into three failing tests.

## Fix

- `InMemoryEventStore`: `ConcurrentDictionary` + `TryAdd`, making creation atomic (exactly one winner, the rest get `EventStreamAlreadyExistsException`).
- `InMemoryEventStream`: a `Lock` guards all reads and writes of the event list; appends compute the version inside the lock, and the `List*` methods materialize a snapshot under the lock so enumeration never observes a mutating list.
- `InMemoryTransactionalBatch`: commits under the owning stream's lock, so batched version computation stays consistent with concurrent direct appends.

No public API changes; `Lock` is fine since the package targets net10.0.

## Tests

First commit adds the failing tests (concurrent creates corrupt the store; concurrent appends lose events/duplicate versions — reproduced 3/3 runs before the fix), second commit makes them pass. A third test pins the exactly-one-winner contract for same-id concurrent creates. Full solution builds; `Papst.EventStore.Tests`, `CodeGeneration.Tests`, and the InMemory tests all pass (the Cosmos/MongoDB integration suites need their emulators and were not run locally).
