### PR TITLE
Bump Swashbuckle.AspNetCore to 10.2.3 to resolve Microsoft.OpenApi vulnerability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
         <PackageVersion Include="Papst.EventStore" Version="[6.1.0,7.0)" />
         <PackageVersion Include="SharpCompress" Version="0.48.1" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />
-        <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.0.1" />
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
         <PackageVersion Include="System.Formats.Asn1" Version="10.0.1" />
         <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
         <PackageVersion Include="Testcontainers" Version="4.11.0" />


### PR DESCRIPTION
Restoring `Papst.EventStore.slnx` emits `NU1903`: the sample project `SampleInMemoryAspNetApi.Api` transitively pulls **Microsoft.OpenApi 2.3.0** via Swashbuckle.AspNetCore 10.0.1, which is affected by [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (high severity — circular schema references may terminate OpenAPI parsing).

This bumps Swashbuckle.AspNetCore to **10.2.3**, which depends on the patched **Microsoft.OpenApi 2.7.5**.

- Restore is clean (no NU1903) across all three solutions
- All solutions build with 0 warnings / 0 errors
- Only the sample project consumes Swashbuckle; no library packages affected

https://claude.ai/code/session_01J2j9sfE7zpM2mJq4dsz6m4