### PR TITLE
Add EventStream deletion to IEventStore and all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Task AppendAsync(
     CancellationToken cancellationToken = default);
 ```
 
-This API is currently only implemented by the Azure Cosmos provider.
+This API is implemented by all EventStore providers (Azure Cosmos, Entity Framework Core, MongoDB, FileSystem and InMemory).
 
 `ILowLevelEventStream` is not resolved directly from `IEventStore`. Instead, obtain an `IEventStream` first and then cast it to `ILowLevelEventStream` when the underlying provider supports it:
 
@@ -90,6 +90,28 @@ if (stream is ILowLevelEventStream lowLevelStream)
 ```
 
 This is intended for scenarios where the event payload or event type is not known at compile time. If you work with strongly typed events, prefer `IEventStream.AppendAsync<TEvent>()`.
+
+## Deleting an Event Stream
+
+The `IEventStore` interface offers a `DeleteAsync` method that permanently removes an event stream together with **all** of its documents (events, snapshots and the stream index):
+
+```csharp
+Task DeleteAsync(
+    Guid streamId,
+    CancellationToken cancellationToken = default);
+```
+
+```csharp
+await eventStore.DeleteAsync(streamId, cancellationToken);
+```
+
+Semantics:
+
+* Deletion is **store-level** — it removes the entire stream identified by `streamId`.
+* If the stream does not exist, an `EventStreamNotFoundException` is thrown.
+* The deletion is **permanent and irreversible**. Every provider hard-deletes the underlying data (dictionary entry, database rows/documents or files) — there is no soft-delete or tombstone.
+
+The action is implemented and logged by every provider (Azure Cosmos, Entity Framework Core, MongoDB, FileSystem and InMemory). See the provider READMEs for provider-specific details.
 
 ## Event Catalog
 
@@ -148,6 +170,16 @@ A full working sample is available at [`samples/SampleEventCatalog/`](./samples/
 For an end-to-end ASP.NET Core example using the in-memory event store, stream aggregation, and read-model repositories, see [`samples/SampleInMemoryAspNetApi/`](./samples/SampleInMemoryAspNetApi/).
 
 # Changelog
+
+## V 6.2
+
+Adds the ability to delete an entire event stream.
+
+### Changes
+
+* Adds `IEventStore.DeleteAsync(Guid streamId, CancellationToken)` which permanently removes a stream and all of its documents.
+* Implemented and logged across all providers (Azure Cosmos, Entity Framework Core, MongoDB, FileSystem and InMemory).
+* Deleting a non-existent stream throws `EventStreamNotFoundException`.
 
 ## V 6.1
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ For an end-to-end ASP.NET Core example using the in-memory event store, stream a
 
 # Changelog
 
-## V 6.2
+## V 6.3
 
 Adds the ability to delete an entire event stream.
 

--- a/src/Papst.EventStore.AzureCosmos/CosmosEventStore.cs
+++ b/src/Papst.EventStore.AzureCosmos/CosmosEventStore.cs
@@ -246,4 +246,50 @@ internal sealed class CosmosEventStore(
       idStrategy,
       timeProvider);
   }
+
+  public async Task DeleteAsync(Guid streamId, CancellationToken cancellationToken = default)
+  {
+    logger.DeletingEventStream(streamId);
+
+    PartitionKey partitionKey = new(streamId.ToString());
+
+    // ensure the stream exists before deleting anything
+    try
+    {
+      await dbProvider.Container
+        .ReadItemAsync<EventStreamIndexEntity>(IndexDocumentName, partitionKey, cancellationToken: cancellationToken)
+        .ConfigureAwait(false);
+    }
+    catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
+    {
+      throw new EventStreamNotFoundException(streamId, "Event Stream has not been found!", e);
+    }
+
+    // all documents of a stream share the same partition key, so we can enumerate and delete them all
+    FeedIterator<PartitionDocumentId> iterator = dbProvider.Container.GetItemQueryIterator<PartitionDocumentId>(
+      new QueryDefinition("SELECT c.id FROM c"),
+      requestOptions: new() { PartitionKey = partitionKey });
+
+    while (iterator.HasMoreResults)
+    {
+      foreach (PartitionDocumentId document in await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false))
+      {
+        using ResponseMessage response = await dbProvider.Container
+          .DeleteItemStreamAsync(document.Id, partitionKey, cancellationToken: cancellationToken)
+          .ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
+        {
+          response.EnsureSuccessStatusCode();
+        }
+      }
+    }
+
+    logger.DeletedEventStream(streamId);
+  }
+
+  private sealed class PartitionDocumentId
+  {
+    [Newtonsoft.Json.JsonProperty("id")]
+    public string Id { get; init; } = string.Empty;
+  }
 }

--- a/src/Papst.EventStore.AzureCosmos/Logging.cs
+++ b/src/Papst.EventStore.AzureCosmos/Logging.cs
@@ -26,4 +26,10 @@ internal static partial class Logging
   
   [LoggerMessage(LogLevel.Information, "Successful Appended Transaction to Stream {StreamId} with {Count} events")]
   public static partial void TransactionCompleted(this ILogger logger, Guid streamId, int count);
+
+  [LoggerMessage(LogLevel.Information, "Deleting EventStream with Id {StreamId}")]
+  public static partial void DeletingEventStream(this ILogger logger, Guid streamId);
+
+  [LoggerMessage(LogLevel.Information, "Deleted EventStream with Id {StreamId}")]
+  public static partial void DeletedEventStream(this ILogger logger, Guid streamId);
 }

--- a/src/Papst.EventStore.AzureCosmos/README.md
+++ b/src/Papst.EventStore.AzureCosmos/README.md
@@ -48,6 +48,16 @@ public class CosmosEventStoreOptions
 }
 ```
 
+## Deleting an Event Stream
+
+`DeleteAsync` removes an entire stream from the Cosmos container. Because every document of a stream (the index document as well as all event and snapshot documents) shares the same `/StreamId` partition key, deletion enumerates all documents in that partition and deletes each of them:
+
+```csharp
+await eventStore.DeleteAsync(streamId);
+```
+
+The stream's existence is verified first by reading its index document; if it is not found, an `EventStreamNotFoundException` is thrown. The action is logged at `Information` level.
+
 ## Migration
 
 With the new V5 based implementation, there is need for an index document in the cosmos database for each stream.

--- a/src/Papst.EventStore.EntityFrameworkCore/EntityFrameworkEventStore.cs
+++ b/src/Papst.EventStore.EntityFrameworkCore/EntityFrameworkEventStore.cs
@@ -100,4 +100,27 @@ public sealed class EntityFrameworkEventStore : IEventStore
       stream,
       _eventTypeProvider);
   }
+
+  public async Task DeleteAsync(Guid streamId, CancellationToken cancellationToken = default)
+  {
+    Logging.DeletingEventStream(_logger, streamId);
+
+    EventStreamEntity? stream = await _dbContext.Streams.FirstOrDefaultAsync(s => s.StreamId == streamId, cancellationToken)
+      .ConfigureAwait(false);
+    if (stream == null)
+    {
+      throw new EventStreamNotFoundException(streamId, "Event Stream Index not found!");
+    }
+
+    List<EventStreamDocumentEntity> documents = await _dbContext.Documents
+      .Where(doc => doc.StreamId == streamId)
+      .ToListAsync(cancellationToken)
+      .ConfigureAwait(false);
+
+    _dbContext.Documents.RemoveRange(documents);
+    _dbContext.Streams.Remove(stream);
+    await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+    Logging.DeletedEventStream(_logger, streamId, documents.Count);
+  }
 }

--- a/src/Papst.EventStore.EntityFrameworkCore/Logging.cs
+++ b/src/Papst.EventStore.EntityFrameworkCore/Logging.cs
@@ -17,4 +17,10 @@ internal static partial class Logging
 
   [LoggerMessage(LogLevel.Debug, "Reading Event {Version} for Stream {StreamId}")]
   public static partial void ReadingEvent(ILogger logger, Guid streamId, ulong version);
+
+  [LoggerMessage(LogLevel.Information, "Deleting EventStream with Id {StreamId}")]
+  public static partial void DeletingEventStream(ILogger logger, Guid streamId);
+
+  [LoggerMessage(LogLevel.Information, "Deleted EventStream with Id {StreamId} including {DocumentCount} documents")]
+  public static partial void DeletedEventStream(ILogger logger, Guid streamId, int documentCount);
 }

--- a/src/Papst.EventStore.EntityFrameworkCore/README.md
+++ b/src/Papst.EventStore.EntityFrameworkCore/README.md
@@ -34,6 +34,16 @@ var evt = JObject.Parse(@"{ ""productId"": ""ABC123"", ""quantity"": 5 }");
 await stream.AppendAsync(Guid.NewGuid(), "ItemAdded", evt);
 ```
 
+### Deleting an Event Stream
+
+`DeleteAsync` removes the stream index row from the `Streams` table and every related document row from the `Documents` table within a single `SaveChangesAsync` call:
+
+```csharp
+await eventStore.DeleteAsync(streamId);
+```
+
+If the stream does not exist, an `EventStreamNotFoundException` is thrown. The action is logged at `Information` level.
+
 ## Configuration
 
 No further configuration is necessary beyond the event store registration.

--- a/src/Papst.EventStore.FileSystem/FileSystemEventStore.cs
+++ b/src/Papst.EventStore.FileSystem/FileSystemEventStore.cs
@@ -129,4 +129,19 @@ internal class FileSystemEventStore : IEventStore
     return new FileSystemEventStream(_loggerFactory.CreateLogger<FileSystemEventStream>(), streamPath, entity,
       _eventTypeProvider);
   }
+
+  public Task DeleteAsync(Guid streamId, CancellationToken cancellationToken = default)
+  {
+    Logging.DeletingEventStream(_logger, streamId);
+    string streamPath = Path.Combine(_path, streamId.ToString());
+    if (!Directory.Exists(streamPath))
+    {
+      throw new EventStreamNotFoundException(streamId, "Event Stream Directory not found");
+    }
+
+    Directory.Delete(streamPath, recursive: true);
+
+    Logging.DeletedEventStream(_logger, streamId);
+    return Task.CompletedTask;
+  }
 }

--- a/src/Papst.EventStore.FileSystem/Logging.cs
+++ b/src/Papst.EventStore.FileSystem/Logging.cs
@@ -19,4 +19,10 @@ internal static partial class Logging
   [LoggerMessage(LogLevel.Debug, "Reading Event {Version} for Stream {StreamId}")]
   public static partial void ReadingEvent(ILogger logger, Guid streamId, ulong version);
 
+  [LoggerMessage(LogLevel.Information, "Deleting EventStream with Id {StreamId}")]
+  public static partial void DeletingEventStream(ILogger logger, Guid streamId);
+
+  [LoggerMessage(LogLevel.Information, "Deleted EventStream with Id {StreamId}")]
+  public static partial void DeletedEventStream(ILogger logger, Guid streamId);
+
 }

--- a/src/Papst.EventStore.FileSystem/README.md
+++ b/src/Papst.EventStore.FileSystem/README.md
@@ -32,6 +32,16 @@ var evt = JObject.Parse(@"{ ""fileData"": ""content"" }");
 await stream.AppendAsync(Guid.NewGuid(), "FileCreated", evt);
 ```
 
+### Deleting an Event Stream
+
+`DeleteAsync` recursively deletes the stream's directory (its index file and all event files) from disk:
+
+```csharp
+await eventStore.DeleteAsync(streamId);
+```
+
+This is a **permanent, hard delete** of the on-disk files. If the stream directory does not exist, an `EventStreamNotFoundException` is thrown. The delete action is logged at `Information` level.
+
 ## Configuration
 
 The FileSystem implementation requires a configuration section with the path where events will be stored:

--- a/src/Papst.EventStore.InMemory/InMemoryEventStore.cs
+++ b/src/Papst.EventStore.InMemory/InMemoryEventStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Papst.EventStore.Exceptions;
 
 namespace Papst.EventStore.InMemory;
@@ -12,11 +13,13 @@ public class InMemoryEventStore : IEventStore
   private readonly ConcurrentDictionary<Guid, InMemoryEventStream> _streams = new();
   private readonly TimeProvider _timeProvider;
   private readonly IEventTypeProvider _eventTypeProvider;
+  private readonly ILogger<InMemoryEventStore> _logger;
 
-  public InMemoryEventStore(TimeProvider timeProvider, IEventTypeProvider eventTypeProvider)
+  public InMemoryEventStore(TimeProvider timeProvider, IEventTypeProvider eventTypeProvider, ILogger<InMemoryEventStore> logger)
   {
     _timeProvider = timeProvider;
     _eventTypeProvider = eventTypeProvider;
+    _logger = logger;
   }
 
   public Task<IEventStream> GetAsync(Guid streamId, CancellationToken cancellationToken = default)
@@ -79,5 +82,19 @@ public class InMemoryEventStore : IEventStore
     }
 
     return Task.FromResult<IEventStream>(stream);
+  }
+
+  public Task DeleteAsync(Guid streamId, CancellationToken cancellationToken = default)
+  {
+    Logging.DeletingEventStream(_logger, streamId);
+
+    if (!_streams.TryRemove(streamId, out _))
+    {
+      throw new EventStreamNotFoundException(streamId,
+        "InMemory Event Streams are not persisted, if you expect this stream here, you should create it first.");
+    }
+
+    Logging.DeletedEventStream(_logger, streamId);
+    return Task.CompletedTask;
   }
 }

--- a/src/Papst.EventStore.InMemory/InMemoryEventStoreProvider.cs
+++ b/src/Papst.EventStore.InMemory/InMemoryEventStoreProvider.cs
@@ -18,7 +18,7 @@ public static class InMemoryEventStoreProvider
     services
       .AddSingleton<IEventStore, InMemoryEventStore>()
       ;
-    
+
     services.TryAddSingleton(TimeProvider.System);
     return services;
   }

--- a/src/Papst.EventStore.InMemory/Logging.cs
+++ b/src/Papst.EventStore.InMemory/Logging.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Papst.EventStore.InMemory;
+
+internal static partial class Logging
+{
+  [LoggerMessage(LogLevel.Information, "Deleting EventStream with Id {StreamId}")]
+  public static partial void DeletingEventStream(ILogger logger, Guid streamId);
+
+  [LoggerMessage(LogLevel.Information, "Deleted EventStream with Id {StreamId}")]
+  public static partial void DeletedEventStream(ILogger logger, Guid streamId);
+}

--- a/src/Papst.EventStore.InMemory/README.md
+++ b/src/Papst.EventStore.InMemory/README.md
@@ -37,3 +37,13 @@ var stream = await lowLevelEventStore.CreateAsync(streamId, "MyAggregate");
 var evt = JObject.Parse(@"{ ""name"": ""John"", ""age"": 30 }");
 await stream.AppendAsync(Guid.NewGuid(), "UserCreated", evt);
 ```
+
+### Deleting an Event Stream
+
+`DeleteAsync` removes the stream from the in-memory dictionary. Because the InMemory store is not persisted, this simply drops the stream and all of its events from memory:
+
+```csharp
+await eventStore.DeleteAsync(streamId);
+```
+
+If the stream does not exist, an `EventStreamNotFoundException` is thrown. The delete action is logged (`Information` level) via the store's `ILogger`.

--- a/src/Papst.EventStore.MongoDB/Logging.cs
+++ b/src/Papst.EventStore.MongoDB/Logging.cs
@@ -34,4 +34,10 @@ internal static partial class Logging
 
   [LoggerMessage(LogLevel.Information, "MongoDB indexes created successfully")]
   public static partial void IndexesCreated(this ILogger logger);
+
+  [LoggerMessage(LogLevel.Information, "Deleting EventStream with Id {StreamId}")]
+  public static partial void DeletingEventStream(this ILogger logger, Guid streamId);
+
+  [LoggerMessage(LogLevel.Information, "Deleted EventStream with Id {StreamId} including {DocumentCount} documents")]
+  public static partial void DeletedEventStream(this ILogger logger, Guid streamId, long documentCount);
 }

--- a/src/Papst.EventStore.MongoDB/MongoDBEventStore.cs
+++ b/src/Papst.EventStore.MongoDB/MongoDBEventStore.cs
@@ -219,6 +219,60 @@ public class MongoDBEventStore : IEventStore, System.IDisposable
     );
   }
 
+  public async Task DeleteAsync(Guid streamId, CancellationToken cancellationToken = default)
+  {
+    _logger.DeletingEventStream(streamId);
+
+    var metadataFilter = Builders<MongoEventStreamMetadata>.Filter.Eq(m => m.StreamId, streamId);
+    var metadata = await _metadataCollection.Find(metadataFilter).FirstOrDefaultAsync(cancellationToken);
+
+    if (metadata == null)
+    {
+      throw new EventStreamNotFoundException(streamId, "Stream not found in MongoDB");
+    }
+
+    var documentsFilter = Builders<EventStreamDocument>.Filter.Eq(d => d.StreamId, streamId);
+
+    // Try to delete documents and metadata atomically using a transaction (replica set).
+    // Fall back to sequential deletes on a standalone MongoDB that does not support transactions.
+    var client = _documentsCollection.Database.Client;
+    long deletedDocuments;
+    try
+    {
+      using var session = await client.StartSessionAsync(cancellationToken: cancellationToken);
+      session.StartTransaction();
+
+      try
+      {
+        var documentsResult = await _documentsCollection.DeleteManyAsync(session, documentsFilter, cancellationToken: cancellationToken);
+        await _metadataCollection.DeleteOneAsync(session, metadataFilter, cancellationToken: cancellationToken);
+
+        await session.CommitTransactionAsync(cancellationToken);
+        deletedDocuments = documentsResult.DeletedCount;
+      }
+      catch (Exception ex)
+      {
+        if (session.IsInTransaction)
+        {
+          await session.AbortTransactionAsync(cancellationToken);
+        }
+        _logger.TransactionException(ex, streamId);
+        throw;
+      }
+    }
+    catch (System.NotSupportedException)
+    {
+      // MongoDB standalone doesn't support transactions, fall back to non-transactional deletes
+      _logger.TransactionNotSupported(streamId);
+
+      var documentsResult = await _documentsCollection.DeleteManyAsync(documentsFilter, cancellationToken);
+      await _metadataCollection.DeleteOneAsync(metadataFilter, cancellationToken);
+      deletedDocuments = documentsResult.DeletedCount;
+    }
+
+    _logger.DeletedEventStream(streamId, deletedDocuments);
+  }
+
   public void Dispose()
   {
     _indexCreationLock?.Dispose();

--- a/src/Papst.EventStore.MongoDB/README.md
+++ b/src/Papst.EventStore.MongoDB/README.md
@@ -29,6 +29,16 @@ var evt = JObject.Parse(@"{ ""eventData"": ""value"" }");
 await stream.AppendAsync(Guid.NewGuid(), "MyEvent", evt);
 ```
 
+### Deleting an Event Stream
+
+`DeleteAsync` removes the stream from **both** collections — all event documents from the `EventStreams` collection and the corresponding entry from the `StreamMetadata` collection:
+
+```csharp
+await eventStore.DeleteAsync(streamId);
+```
+
+On a replica set the two deletes are executed inside a MongoDB transaction to keep them atomic; on a standalone instance (no transaction support) it falls back to sequential deletes, mirroring the batch append behaviour. If the stream does not exist, an `EventStreamNotFoundException` is thrown. The action is logged at `Information` level.
+
 ## Features
 
 - Full IEventStore, ILowLevelEventStore and IEventStream interface implementation

--- a/src/Papst.EventStore/IEventStore.cs
+++ b/src/Papst.EventStore/IEventStore.cs
@@ -61,4 +61,15 @@ public interface IEventStore
     string? comment,
     Dictionary<string, string>? additionalMetaData,
     CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Permanently deletes an <see cref="IEventStream"/> and all of its documents from the store.
+  /// </summary>
+  /// <param name="streamId">Id of the Stream to delete</param>
+  /// <param name="cancellationToken"></param>
+  /// <exception cref="Exceptions.EventStreamNotFoundException">Thrown when the Stream does not exist</exception>
+  /// <returns></returns>
+  Task DeleteAsync(
+    Guid streamId,
+    CancellationToken cancellationToken = default);
 }

--- a/tests/Papst.EventStore.AzureCosmos.Tests/IntegrationTests/CosmosEventStoreTests.cs
+++ b/tests/Papst.EventStore.AzureCosmos.Tests/IntegrationTests/CosmosEventStoreTests.cs
@@ -66,4 +66,61 @@ public class CosmosEventStoreTests : IClassFixture<CosmosDbIntegrationTestFixtur
     stream.ShouldNotBeNull();
     stream.StreamId.ShouldBe(index.StreamId);
   }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveStream(Guid streamId, Guid eventId, string eventType)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+    var lowLevelStream = await eventStore.GetLowLevelAsync(streamId, CancellationToken.None);
+    await lowLevelStream.AppendAsync(eventId, eventType, Newtonsoft.Json.Linq.JObject.FromObject(new { Value = "x" }), cancellationToken: CancellationToken.None);
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+
+    // assert
+    await Should.ThrowAsync<EventStreamNotFoundException>(
+      () => eventStore.GetAsync(streamId, CancellationToken.None));
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_WhenStreamDoesNotExist_ShouldThrow(Guid streamId)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+
+    // act & assert
+    await Should.ThrowAsync<EventStreamNotFoundException>(
+      () => eventStore.DeleteAsync(streamId, CancellationToken.None));
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveAllDocumentsInPartition(Guid streamId, string eventType)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    CosmosClient client = serviceProvider.GetRequiredService<CosmosClient>();
+    var container = client.GetContainer(CosmosDbIntegrationTestFixture.CosmosDatabaseName, CosmosDbIntegrationTestFixture.CosmosContainerId);
+    await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+    var lowLevelStream = await eventStore.GetLowLevelAsync(streamId, CancellationToken.None);
+    for (var i = 0; i < 3; i++)
+    {
+      await lowLevelStream.AppendAsync(Guid.NewGuid(), eventType, Newtonsoft.Json.Linq.JObject.FromObject(new { Index = i }), cancellationToken: CancellationToken.None);
+    }
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+
+    // assert - no documents remain for the stream's partition
+    var iterator = container
+      .GetItemLinqQueryable<EventStreamDocumentEntity>(requestOptions: new() { PartitionKey = new PartitionKey(streamId.ToString()) })
+      .Where(d => d.StreamId == streamId)
+      .ToFeedIterator();
+    var batch = await iterator.ReadNextAsync();
+    batch.Count.ShouldBe(0);
+  }
 }

--- a/tests/Papst.EventStore.EntityFrameworkCore.Tests/IntegrationTests/EntityFrameworkCoreEventStoreTests.cs
+++ b/tests/Papst.EventStore.EntityFrameworkCore.Tests/IntegrationTests/EntityFrameworkCoreEventStoreTests.cs
@@ -1,0 +1,74 @@
+using AutoFixture.Xunit2;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Papst.EventStore;
+using Papst.EventStore.Exceptions;
+using Shouldly;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Papst.EventStore.EntityFrameworkCore.Tests.IntegrationTests;
+
+public class EntityFrameworkCoreEventStoreTests
+{
+  private static EntityFrameworkCoreTestFixture CreateFixture() => new();
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveStream(Guid streamId, Guid eventId, string eventType)
+  {
+    // arrange
+    var serviceProvider = CreateFixture().BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+    var lowLevelStream = await eventStore.GetLowLevelAsync(streamId, CancellationToken.None);
+    await lowLevelStream.AppendAsync(eventId, eventType, JObject.FromObject(new { Value = "x" }), cancellationToken: CancellationToken.None);
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+
+    // assert
+    await Assert.ThrowsAsync<EventStreamNotFoundException>(
+      async () => await eventStore.GetAsync(streamId, CancellationToken.None)
+    );
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_WhenStreamDoesNotExist_ShouldThrow(Guid streamId)
+  {
+    // arrange
+    var serviceProvider = CreateFixture().BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+
+    // act & assert
+    await Assert.ThrowsAsync<EventStreamNotFoundException>(
+      async () => await eventStore.DeleteAsync(streamId, CancellationToken.None)
+    );
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveAllDocuments_AndAllowRecreation(Guid streamId, string eventType)
+  {
+    // arrange
+    var fixture = CreateFixture();
+    var serviceProvider = fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+    var lowLevelStream = await eventStore.GetLowLevelAsync(streamId, CancellationToken.None);
+    for (var i = 0; i < 3; i++)
+    {
+      await lowLevelStream.AppendAsync(Guid.NewGuid(), eventType, JObject.FromObject(new { Index = i }), cancellationToken: CancellationToken.None);
+    }
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+    var recreated = await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+
+    // assert - no leftover documents from the deleted stream
+    var events = await recreated.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
+    events.ShouldBeEmpty();
+    recreated.Version.ShouldBe(0UL);
+  }
+}

--- a/tests/Papst.EventStore.FileSystem.Tests/IntegrationTests/FileSystemEventStoreTests.cs
+++ b/tests/Papst.EventStore.FileSystem.Tests/IntegrationTests/FileSystemEventStoreTests.cs
@@ -1,0 +1,74 @@
+using AutoFixture.Xunit2;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Papst.EventStore;
+using Papst.EventStore.Exceptions;
+using Shouldly;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Papst.EventStore.FileSystem.Tests.IntegrationTests;
+
+public class FileSystemEventStoreTests : IClassFixture<FileSystemTestFixture>
+{
+  private readonly FileSystemTestFixture _fixture;
+
+  public FileSystemEventStoreTests(FileSystemTestFixture fixture) => _fixture = fixture;
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveStream(Guid streamId, Guid eventId, string eventType)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+    var lowLevelStream = await eventStore.GetLowLevelAsync(streamId, CancellationToken.None);
+    await lowLevelStream.AppendAsync(eventId, eventType, JObject.FromObject(new { Value = "x" }), cancellationToken: CancellationToken.None);
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+
+    // assert
+    await Assert.ThrowsAsync<EventStreamNotFoundException>(
+      async () => await eventStore.GetAsync(streamId, CancellationToken.None)
+    );
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_WhenStreamDoesNotExist_ShouldThrow(Guid streamId)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+
+    // act & assert
+    await Assert.ThrowsAsync<EventStreamNotFoundException>(
+      async () => await eventStore.DeleteAsync(streamId, CancellationToken.None)
+    );
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveAllDocuments_AndAllowRecreation(Guid streamId, string eventType)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+    var lowLevelStream = await eventStore.GetLowLevelAsync(streamId, CancellationToken.None);
+    for (var i = 0; i < 3; i++)
+    {
+      await lowLevelStream.AppendAsync(Guid.NewGuid(), eventType, JObject.FromObject(new { Index = i }), cancellationToken: CancellationToken.None);
+    }
+
+    // act & assert - recreating the same stream only succeeds if the previous
+    // directory (and all of its event files) was fully removed by DeleteAsync
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+    var recreated = await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+
+    recreated.StreamId.ShouldBe(streamId);
+    recreated.Version.ShouldBe(0UL);
+  }
+}

--- a/tests/Papst.EventStore.MongoDB.Tests/IntegrationTests/MongoDBEventStoreTests.cs
+++ b/tests/Papst.EventStore.MongoDB.Tests/IntegrationTests/MongoDBEventStoreTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
@@ -76,5 +77,60 @@ public class MongoDBEventStoreTests : IClassFixture<MongoDBIntegrationTestFixtur
     await Assert.ThrowsAsync<EventStreamNotFoundException>(
       async () => await eventStore.GetAsync(streamId, CancellationToken.None)
     );
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveStream(Guid streamId, Guid eventId, string eventType)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+    var lowLevelStream = await eventStore.GetLowLevelAsync(streamId, CancellationToken.None);
+    await lowLevelStream.AppendAsync(eventId, eventType, Newtonsoft.Json.Linq.JObject.FromObject(new { Value = "x" }), cancellationToken: CancellationToken.None);
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+
+    // assert
+    await Assert.ThrowsAsync<EventStreamNotFoundException>(
+      async () => await eventStore.GetAsync(streamId, CancellationToken.None)
+    );
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_WhenStreamDoesNotExist_ShouldThrow(Guid streamId)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+
+    // act & assert
+    await Assert.ThrowsAsync<EventStreamNotFoundException>(
+      async () => await eventStore.DeleteAsync(streamId, CancellationToken.None)
+    );
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveAllDocuments_AndAllowRecreation(Guid streamId, string eventType)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+    var lowLevelStream = await eventStore.GetLowLevelAsync(streamId, CancellationToken.None);
+    for (var i = 0; i < 3; i++)
+    {
+      await lowLevelStream.AppendAsync(Guid.NewGuid(), eventType, Newtonsoft.Json.Linq.JObject.FromObject(new { Index = i }), cancellationToken: CancellationToken.None);
+    }
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+    var recreated = await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+
+    // assert - no leftover documents from the deleted stream
+    var events = await recreated.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
+    events.ShouldBeEmpty();
+    recreated.Version.ShouldBe(0UL);
   }
 }

--- a/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStoreTests.cs
+++ b/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStoreTests.cs
@@ -71,4 +71,49 @@ public class InMemoryEventStoreTests : IClassFixture<InMemoryTestFixture>
     results.Count(r => r is null).ShouldBe(1);
     results.Where(r => r is not null).ShouldAllBe(r => r is EventStreamAlreadyExistsException);
   }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldRemoveStream(Guid streamId)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+
+    // assert
+    await Should.ThrowAsync<EventStreamNotFoundException>(
+      () => eventStore.GetAsync(streamId, CancellationToken.None));
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_WhenStreamDoesNotExist_ShouldThrow(Guid streamId)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+
+    // act & assert
+    await Should.ThrowAsync<EventStreamNotFoundException>(
+      () => eventStore.DeleteAsync(streamId, CancellationToken.None));
+  }
+
+  [Theory, AutoData]
+  public async Task DeleteAsync_ShouldAllowRecreatingStream(Guid streamId)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+
+    // act
+    await eventStore.DeleteAsync(streamId, CancellationToken.None);
+    var recreated = await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+
+    // assert
+    recreated.StreamId.ShouldBe(streamId);
+    recreated.Version.ShouldBe(0UL);
+  }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2",
+  "version": "6.3",
   "publicReleaseRefSpec": [
     "^refs/heads/main"
   ],


### PR DESCRIPTION
## What

Adds a store-level `Task DeleteAsync(Guid streamId, CancellationToken)` to `IEventStore` that permanently removes an event stream together with **all** of its documents (events, snapshots and the stream index).

## Why

The event store was strictly append-only — there was no way to remove a stream. This adds a first-class delete capability so callers can permanently drop a stream and reclaim its storage.

## Changes

- **Core**: new `IEventStore.DeleteAsync`. Deleting a non-existent stream throws `EventStreamNotFoundException` (consistent with `GetAsync`).
- **Providers** (each logs the delete action via its `Logging.cs`):
  - **InMemory** — `ConcurrentDictionary` removal; added a `Logging.cs` and injected `ILogger<InMemoryEventStore>` (previously had no logger).
  - **EntityFrameworkCore** — removes the `Streams` row + all related `Documents` rows in one `SaveChangesAsync`.
  - **AzureCosmos** — verifies the index doc, then enumerates and deletes every document in the stream's `/StreamId` partition.
  - **MongoDB** — deletes from both the events and metadata collections; transactional on replica sets with a standalone fallback (mirrors the batch-append pattern).
  - **FileSystem** — recursive directory delete.
- **Tests** — delete tests per provider (remove + throw-on-missing + no-leftover-documents), including new `*EventStoreTests` for EFCore and FileSystem.
- **Docs** — root README gains a "Deleting an Event Stream" section + V6.2 changelog entry (and fixes a stale note claiming low-level access was Cosmos-only); all five provider READMEs get a delete subsection.

## Scope note

Delete is exposed on `IEventStore` only (store-level), not on `IEventStream`.

## Testing

`dotnet build` succeeds (0 warnings/0 errors). Passing suites: core (54), InMemory (18), FileSystem (8), EFCore (8), CodeGeneration (20), **AzureCosmos (13, real emulator container)**.

⚠️ **MongoDB integration tests were not executed** — the dev host's kernel (6.19+) is incompatible with MongoDB 8.0, so the Testcontainer exits on startup ([SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912)) and every Mongo test fails identically (including pre-existing ones). The MongoDB delete code compiles and follows the provider's existing transaction/fallback pattern, but please run `dotnet test tests/Papst.EventStore.MongoDB.Tests` in CI or on a compatible host to confirm.