### PR TITLE
Align event version numbering to 0-based across all stores (#282)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,24 @@ For an end-to-end ASP.NET Core example using the in-memory event store, stream a
 
 # Changelog
 
+## V 6.4
+
+Aligns the event version numbering across all stores and lets the aggregator target the creation event.
+
+### Changes
+
+* The `InMemory` and `MongoDB` stores now number the **first event of a stream `0`**, matching the
+  Azure Cosmos, Entity Framework Core and FileSystem stores. Previously they were 1-based, which made
+  `InMemory` an unreliable stand-in for Cosmos in tests (see
+  [#282](https://github.com/PapstIO/Papst.EventStore/issues/282)).
+* `EventRegistrationEventAggregator` can now aggregate up to and including version `0` (the creation
+  event on 0-based stores). The stop condition compares the event version instead of the aggregate
+  version, so `AggregateAsync(stream, 0, ct)` stops after the creation event instead of replaying the
+  whole stream.
+* **Breaking (MongoDB):** existing persisted MongoDB streams created with an earlier version are 1-based;
+  their metadata gains a `NextVersion` field that defaults to `0`. Streams created before upgrading need
+  to be migrated (or recreated) before appending further events.
+
 ## V 6.3
 
 Adds the ability to delete an entire event stream.

--- a/src/Papst.EventStore.Aggregation.EventRegistration/EventRegistrationEventAggregator.cs
+++ b/src/Papst.EventStore.Aggregation.EventRegistration/EventRegistrationEventAggregator.cs
@@ -95,10 +95,13 @@ internal class EventRegistrationEventAggregator<TEntity> : IEventStreamAggregato
           EventTime = evt.Time
         };
 
-        if (targetVersion > 0 && target.Version == targetVersion)
+        if (evt.Version > targetVersion)
         {
-          // if the current version is already the target version, stop the aggregation,
-          // but only if the target version is greater than 0 it should apply the creation event
+          // Stop before applying an event beyond the requested target version.
+          // Comparing the event's own version (rather than the already-applied
+          // aggregate version) lets callers target version 0 - the creation event on
+          // 0-based stores - which the previous `targetVersion > 0` guard made
+          // unreachable.
           break;
         }
 

--- a/src/Papst.EventStore.InMemory/InMemoryEventStream.cs
+++ b/src/Papst.EventStore.InMemory/InMemoryEventStream.cs
@@ -53,6 +53,11 @@ internal class InMemoryEventStream : IEventStream, ILowLevelEventStream
 
   private ulong VersionUnlocked => _events.Count == 0 ? _initialVersion : _events.Max(e => e.Version);
 
+  // Version to assign to the next appended event. An empty stream starts at 0 so the
+  // first event is version 0, matching the persisted stores (Cosmos, EF Core, FileSystem)
+  // and making this in-memory store a faithful test double for them.
+  private ulong NextVersionUnlocked => _events.Count == 0 ? _initialVersion : _events.Max(e => e.Version) + 1;
+
   public DateTimeOffset Created { get; }
 
   public ulong? LatestSnapshotVersion
@@ -88,7 +93,7 @@ internal class InMemoryEventStream : IEventStream, ILowLevelEventStream
       _events.Add(new EventStreamDocument()
       {
         StreamId = StreamId,
-        Version = VersionUnlocked + 1,
+        Version = NextVersionUnlocked,
         Time = _tp.GetLocalNow(),
         DataType = name,
         Data = JObject.FromObject(evt),
@@ -106,19 +111,22 @@ internal class InMemoryEventStream : IEventStream, ILowLevelEventStream
   public Task AppendAsync(Guid id, string eventType, JObject evt, EventStreamMetaData? metaData = null,
     CancellationToken cancellationToken = default)
   {
-    _events.Add(new EventStreamDocument()
+    lock (_lock)
     {
-      StreamId = StreamId,
-      Version = Version + 1,
-      Time = _tp.GetLocalNow(),
-      DataType = eventType,
-      Data = evt,
-      DocumentType = EventStreamDocumentType.Event,
-      MetaData = metaData ?? new EventStreamMetaData(),
-      TargetType = _targetType,
-      Id = id,
-      Name = eventType
-    });
+      _events.Add(new EventStreamDocument()
+      {
+        StreamId = StreamId,
+        Version = NextVersionUnlocked,
+        Time = _tp.GetLocalNow(),
+        DataType = eventType,
+        Data = evt,
+        DocumentType = EventStreamDocumentType.Event,
+        MetaData = metaData ?? new EventStreamMetaData(),
+        TargetType = _targetType,
+        Id = id,
+        Name = eventType
+      });
+    }
 
     return Task.CompletedTask;
   }
@@ -131,7 +139,7 @@ internal class InMemoryEventStream : IEventStream, ILowLevelEventStream
       _events.Add(new EventStreamDocument()
       {
         StreamId = StreamId,
-        Version = VersionUnlocked + 1,
+        Version = NextVersionUnlocked,
         Time = _tp.GetLocalNow(),
         DataType = _targetType,
         Data = JObject.FromObject(entity),
@@ -220,7 +228,7 @@ internal class InMemoryTransactionalBatch(
     _actions.Add(() => events.Add(new EventStreamDocument()
     {
       StreamId = streamId,
-      Version = (events.Count == 0 ? 0UL : events.Max(e => e.Version)) + 1,
+      Version = events.Count == 0 ? 0UL : events.Max(e => e.Version) + 1,
       Time = tp.GetLocalNow(),
       DataType = name,
       Data = JObject.FromObject(evt),

--- a/src/Papst.EventStore.MongoDB/MongoDBEventStore.cs
+++ b/src/Papst.EventStore.MongoDB/MongoDBEventStore.cs
@@ -124,6 +124,7 @@ public class MongoDBEventStore : IEventStore, System.IDisposable
     return new MongoDBEventStream(
       metadata.StreamId,
       metadata.Version,
+      metadata.NextVersion,
       metadata.Created,
       metadata.MetaData,
       metadata.TargetTypeName,
@@ -150,6 +151,7 @@ public class MongoDBEventStore : IEventStore, System.IDisposable
     return new MongoDBEventStream(
       metadata.StreamId,
       metadata.Version,
+      metadata.NextVersion,
       metadata.Created,
       metadata.MetaData,
       metadata.TargetTypeName,
@@ -183,6 +185,7 @@ public class MongoDBEventStore : IEventStore, System.IDisposable
     {
       StreamId = streamId,
       Version = 0,
+      NextVersion = 0,
       Created = _timeProvider.GetLocalNow(),
       TargetTypeName = targetTypeName,
       MetaData = new EventStreamMetaData
@@ -208,6 +211,7 @@ public class MongoDBEventStore : IEventStore, System.IDisposable
     return new MongoDBEventStream(
       metadata.StreamId,
       metadata.Version,
+      metadata.NextVersion,
       metadata.Created,
       metadata.MetaData,
       metadata.TargetTypeName,

--- a/src/Papst.EventStore.MongoDB/MongoDBEventStream.cs
+++ b/src/Papst.EventStore.MongoDB/MongoDBEventStream.cs
@@ -23,6 +23,7 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
   public MongoDBEventStream(
     Guid streamId,
     ulong version,
+    ulong nextVersion,
     DateTimeOffset created,
     EventStreamMetaData metaData,
     string targetType,
@@ -34,6 +35,7 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
   {
     StreamId = streamId;
     Version = version;
+    NextVersion = nextVersion;
     Created = created;
     MetaData = metaData;
     _targetType = targetType;
@@ -46,6 +48,11 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
 
   public Guid StreamId { get; }
   public ulong Version { get; private set; }
+
+  // Version to assign to the next appended event. Tracked alongside Version so the first
+  // event of a freshly created stream is version 0 (an empty stream also reports Version 0).
+  private ulong NextVersion { get; set; }
+
   public DateTimeOffset Created { get; }
   public EventStreamMetaData MetaData { get; private set; }
 
@@ -80,7 +87,7 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
     CancellationToken cancellationToken = default) where TEvent : notnull
   {
     string name = _typeProvider.ResolveType(typeof(TEvent));
-    var newVersion = Version + 1;
+    var newVersion = NextVersion;
 
     _logger.AppendingEvent(name, StreamId, newVersion);
 
@@ -102,10 +109,13 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
 
     // Update version in metadata
     var filter = Builders<MongoEventStreamMetadata>.Filter.Eq(m => m.StreamId, StreamId);
-    var update = Builders<MongoEventStreamMetadata>.Update.Set(m => m.Version, newVersion);
+    var update = Builders<MongoEventStreamMetadata>.Update
+      .Set(m => m.Version, newVersion)
+      .Set(m => m.NextVersion, newVersion + 1);
     await _metadataCollection.UpdateOneAsync(filter, update, new UpdateOptions(), cancellationToken);
 
     Version = newVersion;
+    NextVersion = newVersion + 1;
   }
 
   public async Task AppendAsync(
@@ -115,7 +125,7 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
     EventStreamMetaData? metaData = null,
     CancellationToken cancellationToken = default)
   {
-    var newVersion = Version + 1;
+    var newVersion = NextVersion;
 
     _logger.AppendingEvent(eventType, StreamId, newVersion);
 
@@ -137,10 +147,13 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
 
     // Update version in metadata
     var mongoFilter = Builders<MongoEventStreamMetadata>.Filter.Eq(m => m.StreamId, StreamId);
-    var mongoUpdate = Builders<MongoEventStreamMetadata>.Update.Set(m => m.Version, newVersion);
+    var mongoUpdate = Builders<MongoEventStreamMetadata>.Update
+      .Set(m => m.Version, newVersion)
+      .Set(m => m.NextVersion, newVersion + 1);
     await _metadataCollection.UpdateOneAsync(mongoFilter, mongoUpdate, new UpdateOptions(), cancellationToken);
 
     Version = newVersion;
+    NextVersion = newVersion + 1;
   }
 
   public async Task AppendSnapshotAsync<TEntity>(
@@ -149,7 +162,7 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
     EventStreamMetaData? metaData = null,
     CancellationToken cancellationToken = default) where TEntity : notnull
   {
-    var newVersion = Version + 1;
+    var newVersion = NextVersion;
 
     _logger.AppendingSnapshot(StreamId, newVersion);
 
@@ -173,10 +186,12 @@ internal class MongoDBEventStream : IEventStream, ILowLevelEventStream
     var filter = Builders<MongoEventStreamMetadata>.Filter.Eq(m => m.StreamId, StreamId);
     var update = Builders<MongoEventStreamMetadata>.Update
       .Set(m => m.Version, newVersion)
+      .Set(m => m.NextVersion, newVersion + 1)
       .Set(m => m.LatestSnapshotVersion, newVersion);
     await _metadataCollection.UpdateOneAsync(filter, update, new UpdateOptions(), cancellationToken);
 
     Version = newVersion;
+    NextVersion = newVersion + 1;
   }
 
   public Task<IEventStoreTransactionAppender> CreateTransactionalBatchAsync()

--- a/src/Papst.EventStore.MongoDB/MongoDBTransactionalBatch.cs
+++ b/src/Papst.EventStore.MongoDB/MongoDBTransactionalBatch.cs
@@ -80,12 +80,14 @@ internal class MongoDBTransactionalBatch : IEventStoreTransactionAppender
       throw new InvalidOperationException($"Stream {_streamId} not found");
     }
 
-    ulong currentVersion = metadata.Version;
+    // NextVersion is the version to assign to the first pending document (0 on a freshly
+    // created stream), so events are numbered 0-based like the other stores.
+    ulong baseVersion = metadata.NextVersion;
 
     // Assign versions to pending documents
     for (int i = 0; i < _pendingDocuments.Count; i++)
     {
-      _pendingDocuments[i] = _pendingDocuments[i] with { Version = currentVersion + (ulong)(i + 1) };
+      _pendingDocuments[i] = _pendingDocuments[i] with { Version = baseVersion + (ulong)i };
     }
 
     // Try to use a transaction if MongoDB supports it (replica set)
@@ -102,8 +104,10 @@ internal class MongoDBTransactionalBatch : IEventStoreTransactionAppender
         await _documentsCollection.InsertManyAsync(session, _pendingDocuments, new InsertManyOptions(), cancellationToken);
 
         // Update version in metadata
-        var newVersion = currentVersion + (ulong)_pendingDocuments.Count;
-        var update = Builders<MongoEventStreamMetadata>.Update.Set(m => m.Version, newVersion);
+        var newVersion = baseVersion + (ulong)_pendingDocuments.Count - 1;
+        var update = Builders<MongoEventStreamMetadata>.Update
+          .Set(m => m.Version, newVersion)
+          .Set(m => m.NextVersion, newVersion + 1);
         await _metadataCollection.UpdateOneAsync(session, filter, update, new UpdateOptions(), cancellationToken);
 
         await session.CommitTransactionAsync(cancellationToken);
@@ -126,8 +130,10 @@ internal class MongoDBTransactionalBatch : IEventStoreTransactionAppender
       
       await _documentsCollection.InsertManyAsync(_pendingDocuments, new InsertManyOptions(), cancellationToken);
 
-      var newVersion = currentVersion + (ulong)_pendingDocuments.Count;
-      var update = Builders<MongoEventStreamMetadata>.Update.Set(m => m.Version, newVersion);
+      var newVersion = baseVersion + (ulong)_pendingDocuments.Count - 1;
+      var update = Builders<MongoEventStreamMetadata>.Update
+        .Set(m => m.Version, newVersion)
+        .Set(m => m.NextVersion, newVersion + 1);
       await _metadataCollection.UpdateOneAsync(filter, update, new UpdateOptions(), cancellationToken);
     }
   }

--- a/src/Papst.EventStore.MongoDB/MongoEventStreamMetadata.cs
+++ b/src/Papst.EventStore.MongoDB/MongoEventStreamMetadata.cs
@@ -14,6 +14,14 @@ internal class MongoEventStreamMetadata
   public Guid StreamId { get; set; }
   
   public ulong Version { get; set; }
+
+  /// <summary>
+  /// Version to assign to the next appended event. Newly created streams start at 0 so
+  /// the first event is version 0, matching the other stores (Azure Cosmos, EF Core,
+  /// FileSystem).
+  /// </summary>
+  public ulong NextVersion { get; set; }
+
   public DateTimeOffset Created { get; set; }
   public string TargetTypeName { get; set; } = string.Empty;
   public EventStreamMetaData MetaData { get; set; } = new();

--- a/tests/Papst.EventStore.AzureCosmos.Tests/Papst.EventStore.AzureCosmos.Tests.csproj
+++ b/tests/Papst.EventStore.AzureCosmos.Tests/Papst.EventStore.AzureCosmos.Tests.csproj
@@ -36,6 +36,11 @@
 
 
 	<ItemGroup>
+		<Compile Include="..\Shared\TestcontainersRuntime.cs" Link="TestcontainersRuntime.cs" />
+	</ItemGroup>
+
+
+	<ItemGroup>
 		<ProjectReference Include="..\..\src\Papst.EventStore.Aggregation.EventRegistration\Papst.EventStore.Aggregation.EventRegistration.csproj" />
 		<ProjectReference Include="..\..\src\Papst.EventStore.AzureCosmos\Papst.EventStore.AzureCosmos.csproj" />
 		<ProjectReference Include="..\..\src\Papst.EventStore\Papst.EventStore.csproj" />

--- a/tests/Papst.EventStore.MongoDB.Tests/IntegrationTests/MongoDBEventStreamTests.cs
+++ b/tests/Papst.EventStore.MongoDB.Tests/IntegrationTests/MongoDBEventStreamTests.cs
@@ -50,6 +50,23 @@ public class MongoDBEventStreamTests : IClassFixture<MongoDBIntegrationTestFixtu
   }
 
   [Theory, AutoData]
+  public async Task AppendAsync_ShouldNumberFirstEventZero(Guid streamId, TestEvent testEvent)
+  {
+    // arrange
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    var stream = await eventStore.CreateAsync(streamId, "TestType", CancellationToken.None);
+
+    // act
+    await stream.AppendAsync(Guid.NewGuid(), testEvent, cancellationToken: CancellationToken.None);
+
+    // assert
+    var events = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
+    events.Single().Version.ShouldBe(0UL);
+    stream.Version.ShouldBe(0UL);
+  }
+
+  [Theory, AutoData]
   public async Task ListAsync_ShouldReturnEntries(List<TestEvent> testEvents, Guid streamId)
   {
     // arrange

--- a/tests/Papst.EventStore.MongoDB.Tests/Papst.EventStore.MongoDB.Tests.csproj
+++ b/tests/Papst.EventStore.MongoDB.Tests/Papst.EventStore.MongoDB.Tests.csproj
@@ -29,6 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\TestcontainersRuntime.cs" Link="TestcontainersRuntime.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Papst.EventStore.Aggregation.EventRegistration\Papst.EventStore.Aggregation.EventRegistration.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore.MongoDB\Papst.EventStore.MongoDB.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore\Papst.EventStore.csproj" />

--- a/tests/Papst.EventStore.Tests/EventRegistrationEventAggregatorTests.cs
+++ b/tests/Papst.EventStore.Tests/EventRegistrationEventAggregatorTests.cs
@@ -61,6 +61,39 @@ public class EventRegistrationEventAggregatorTests
     entity.Tags.ShouldBe(["a", "b"]);
   }
 
+  [Fact]
+  public async Task AggregateAsync_StopsAtTargetVersionZero_AppliesOnlyCreationEvent()
+  {
+    // On 0-based stores version 0 is the creation event - a real, restorable state that
+    // must be reachable as a stop point.
+    var aggregator = BuildAggregator();
+    var stream = new FakeEventStream();
+    stream.Append(new IncrementEvent("a")); // version 0
+    stream.Append(new IncrementEvent("b")); // version 1
+
+    var entity = await aggregator.AggregateAsync(stream, 0UL, CancellationToken.None);
+
+    entity.ShouldNotBeNull();
+    entity.Version.ShouldBe(0UL);
+    entity.Tags.ShouldBe(["a"]);
+  }
+
+  [Fact]
+  public async Task AggregateAsync_StopsAtTargetVersion_IncludingTheTargetEvent()
+  {
+    var aggregator = BuildAggregator();
+    var stream = new FakeEventStream();
+    stream.Append(new IncrementEvent("a")); // version 0
+    stream.Append(new IncrementEvent("b")); // version 1
+    stream.Append(new IncrementEvent("c")); // version 2
+
+    var entity = await aggregator.AggregateAsync(stream, 1UL, CancellationToken.None);
+
+    entity.ShouldNotBeNull();
+    entity.Version.ShouldBe(1UL);
+    entity.Tags.ShouldBe(["a", "b"]);
+  }
+
   private static IEventStreamAggregator<CountingEntity> BuildAggregator()
   {
     var registration = new EventDescriptionEventRegistration();

--- a/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStreamTests.cs
+++ b/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/InMemoryEventStreamTests.cs
@@ -52,6 +52,20 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
   }
 
   [Theory, AutoData]
+  public async Task AppendAsync_ShouldNumberFirstEventZero(TestEvent first, Guid streamId)
+  {
+    var serviceProvider = _fixture.BuildServiceProvider();
+    var eventStore = serviceProvider.GetRequiredService<IEventStore>();
+    var stream = await eventStore.CreateAsync(streamId, "", CancellationToken.None);
+
+    await stream.AppendAsync(Guid.NewGuid(), first, cancellationToken: CancellationToken.None);
+
+    var result = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
+    result.Single().Version.ShouldBe(0UL);
+    stream.Version.ShouldBe(0UL);
+  }
+
+  [Theory, AutoData]
   public async Task AppendAsync_ShouldAssignSequentialEventVersions(List<TestEvent> events, Guid streamId)
   {
     var serviceProvider = _fixture.BuildServiceProvider();
@@ -64,7 +78,7 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
 
     var result = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
 
-    result.Select(e => e.Version).ShouldBe(Enumerable.Range(1, events.Count).Select(i => (ulong)i));
+    result.Select(e => e.Version).ShouldBe(Enumerable.Range(0, events.Count).Select(i => (ulong)i));
   }
 
   [Theory, AutoData]
@@ -78,7 +92,8 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
       await stream.AppendAsync(Guid.NewGuid(), @event, cancellationToken: CancellationToken.None);
     }
 
-    stream.Version.ShouldBe((ulong)events.Count);
+    // 0-based versions: after N events the latest version is N - 1.
+    stream.Version.ShouldBe((ulong)events.Count - 1);
   }
 
   [Theory, AutoData]
@@ -91,12 +106,12 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
     await stream.AppendSnapshotAsync(Guid.NewGuid(), snapshot, cancellationToken: CancellationToken.None);
 
     var documents = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
-    documents.Select(d => d.Version).ShouldBe([1UL, 2UL]);
-    stream.Version.ShouldBe(2UL);
+    documents.Select(d => d.Version).ShouldBe([0UL, 1UL]);
+    stream.Version.ShouldBe(1UL);
   }
 
   [Theory, AutoData]
-  public async Task ListAsync_FromVersionGreaterThanOne_ShouldReturnEventsAppendedAfterFirst(TestEvent first, TestEvent second, Guid streamId)
+  public async Task ListAsync_FromVersionGreaterThanZero_ShouldReturnEventsAppendedAfterFirst(TestEvent first, TestEvent second, Guid streamId)
   {
     var serviceProvider = _fixture.BuildServiceProvider();
     var eventStore = serviceProvider.GetRequiredService<IEventStore>();
@@ -104,7 +119,7 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
     await stream.AppendAsync(Guid.NewGuid(), first, cancellationToken: CancellationToken.None);
     await stream.AppendAsync(Guid.NewGuid(), second, cancellationToken: CancellationToken.None);
 
-    var result = await stream.ListAsync(2, CancellationToken.None).ToListAsync(CancellationToken.None);
+    var result = await stream.ListAsync(1, CancellationToken.None).ToListAsync(CancellationToken.None);
 
     result.Count.ShouldBe(1);
     result[0].Data.ToObject<TestEvent>().ShouldBe(second);
@@ -123,7 +138,7 @@ public class InMemoryEventStreamTests: IClassFixture<InMemoryTestFixture>
       Task.Run(() => stream.AppendAsync(Guid.NewGuid(), @event, cancellationToken: CancellationToken.None))));
 
     // assert
-    stream.Version.ShouldBe(500UL);
+    stream.Version.ShouldBe(499UL);
     var documents = await stream.ListAsync(0, CancellationToken.None).ToListAsync(CancellationToken.None);
     documents.Count.ShouldBe(500);
     documents.Select(d => d.Version).ShouldBeUnique();

--- a/tests/Shared/TestcontainersRuntime.cs
+++ b/tests/Shared/TestcontainersRuntime.cs
@@ -1,0 +1,328 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace Papst.EventStore.Testing;
+
+/// <summary>
+/// Configures Testcontainers to talk to a Podman engine when Docker is not the active
+/// container runtime, so the integration tests run unchanged from:
+/// <list type="bullet">
+///   <item>Windows / Visual Studio with Podman Desktop (WSL backend),</item>
+///   <item>macOS with a Podman machine,</item>
+///   <item>a Linux GitHub Actions runner (Docker by default, or rootless Podman).</item>
+/// </list>
+/// The work runs once at assembly load - before Testcontainers reads its settings - and only
+/// fills in configuration that has not been provided explicitly. An existing <c>DOCKER_HOST</c>
+/// or a plain Docker environment is therefore left completely untouched, so nothing changes on
+/// a Docker-based CI runner.
+/// </summary>
+/// <remarks>
+/// This file is linked into every integration-test project that uses Testcontainers, so each
+/// test assembly gets its own module initializer.
+/// </remarks>
+internal static class TestcontainersRuntime
+{
+  private static int _initialized;
+
+  [ModuleInitializer]
+  internal static void Initialize()
+  {
+    if (Interlocked.Exchange(ref _initialized, 1) != 0)
+    {
+      return;
+    }
+
+    try
+    {
+      Configure();
+    }
+    catch
+    {
+      // Detection is best-effort: on any failure fall back to the Testcontainers defaults
+      // rather than breaking the test run.
+    }
+  }
+
+  private static void Configure()
+  {
+    // Respect an explicitly configured endpoint (CI, custom developer setups): if the caller
+    // already told Testcontainers where the engine is, do not second-guess it.
+    if (HasValue("DOCKER_HOST"))
+    {
+      return;
+    }
+
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      ConfigureWindows();
+    }
+    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      ConfigureMacOs();
+    }
+    else
+    {
+      ConfigureLinux();
+    }
+  }
+
+  private static void ConfigureWindows()
+  {
+    // Podman Desktop runs the engine inside a WSL machine and exposes a Docker-compatible
+    // named pipe. The presence of the podman-machine pipe tells us Podman is the active engine
+    // (a plain Docker Desktop install would not create it), so we leave Docker Desktop alone.
+    if (!WindowsPipeExists("podman-machine-default"))
+    {
+      return;
+    }
+
+    SetIfMissing("DOCKER_HOST", "npipe://./pipe/docker_engine");
+    DisableRyuk();
+
+    // Podman's WSL machine does not forward published container ports to the Windows host, so
+    // point Testcontainers at the machine's IP address instead of localhost.
+    string? ip = TryGetPodmanWslIp();
+    if (ip is not null)
+    {
+      SetIfMissing("TESTCONTAINERS_HOST_OVERRIDE", ip);
+    }
+  }
+
+  private static void ConfigureMacOs()
+  {
+    // Ask Podman for its (Docker-compatible) API socket. If Podman is not installed/running we
+    // get nothing back and fall through to the Docker default.
+    string? socket = FirstLine(RunProcess("podman", "machine inspect --format {{.ConnectionInfo.PodmanSocket.Path}}"));
+    if (string.IsNullOrEmpty(socket) || !File.Exists(socket))
+    {
+      return;
+    }
+
+    SetIfMissing("DOCKER_HOST", "unix://" + socket);
+    DisableRyuk();
+    // A macOS Podman machine forwards published ports to localhost, so no host override needed.
+  }
+
+  private static void ConfigureLinux()
+  {
+    // Docker (the default on GitHub Actions Linux runners) works with no configuration.
+    if (File.Exists("/var/run/docker.sock"))
+    {
+      return;
+    }
+
+    // Otherwise look for a rootless (then rootful) Podman socket.
+    var candidates = new List<string>();
+    string? runtimeDir = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
+    if (!string.IsNullOrEmpty(runtimeDir))
+    {
+      candidates.Add(Path.Combine(runtimeDir, "podman", "podman.sock"));
+    }
+
+    candidates.Add("/run/podman/podman.sock");
+
+    foreach (string socket in candidates)
+    {
+      if (File.Exists(socket))
+      {
+        SetIfMissing("DOCKER_HOST", "unix://" + socket);
+        DisableRyuk();
+        return;
+      }
+    }
+  }
+
+  /// <summary>
+  /// The Podman machine on Windows is a WSL distribution; read the IP of its primary network
+  /// interface so container ports can be reached directly.
+  /// </summary>
+  private static string? TryGetPodmanWslIp()
+  {
+    foreach (string distro in new[] { "podman-machine-default" })
+    {
+      string? output = RunProcess("wsl.exe", $"-d {distro} -- ip -4 -o addr show eth0");
+      if (output is null)
+      {
+        continue;
+      }
+
+      Match match = Regex.Match(output, @"inet\s+(\d+\.\d+\.\d+\.\d+)");
+      if (match.Success)
+      {
+        return match.Groups[1].Value;
+      }
+    }
+
+    return null;
+  }
+
+  private static bool WindowsPipeExists(string name)
+  {
+    try
+    {
+      foreach (string pipe in Directory.EnumerateFiles(@"\\.\pipe\"))
+      {
+        if (string.Equals(Path.GetFileName(pipe), name, StringComparison.OrdinalIgnoreCase))
+        {
+          return true;
+        }
+      }
+    }
+    catch
+    {
+      // Enumerating the pipe filesystem can throw on some Windows configurations; treat as absent.
+    }
+
+    return false;
+  }
+
+  private static void DisableRyuk() =>
+    // Ryuk, the Testcontainers resource reaper, needs privileges rootless Podman does not grant.
+    // Fixtures clean up their own containers via WithAutoRemove()/DisposeAsync().
+    SetIfMissing("TESTCONTAINERS_RYUK_DISABLED", "true");
+
+  private static bool HasValue(string name) =>
+    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(name));
+
+  private static void SetIfMissing(string name, string value)
+  {
+    if (!HasValue(name))
+    {
+      Environment.SetEnvironmentVariable(name, value);
+    }
+  }
+
+  private static string? FirstLine(string? value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return null;
+    }
+
+    foreach (string line in value.Split('\n'))
+    {
+      string trimmed = line.Trim();
+      if (trimmed.Length > 0)
+      {
+        return trimmed;
+      }
+    }
+
+    return null;
+  }
+
+  private static string? RunProcess(string fileName, string arguments)
+  {
+    string? executable = ResolveExecutable(fileName);
+    if (executable is null)
+    {
+      return null;
+    }
+
+    try
+    {
+      using var process = new Process
+      {
+        StartInfo = new ProcessStartInfo(executable, arguments)
+        {
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+          UseShellExecute = false,
+          CreateNoWindow = true,
+        },
+      };
+
+      process.Start();
+      string stdout = process.StandardOutput.ReadToEnd();
+      _ = process.StandardError.ReadToEnd(); // drain so the child cannot block on a full pipe
+      if (!process.WaitForExit(15_000))
+      {
+        try
+        {
+          process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+          // ignored
+        }
+
+        return null;
+      }
+
+      return stdout;
+    }
+    catch
+    {
+      return null;
+    }
+  }
+
+  private static string? ResolveExecutable(string name)
+  {
+    bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+    string[] extensions = isWindows ? new[] { string.Empty, ".exe" } : new[] { string.Empty };
+
+    string pathVariable = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+    foreach (string dir in pathVariable.Split(Path.PathSeparator))
+    {
+      if (string.IsNullOrWhiteSpace(dir))
+      {
+        continue;
+      }
+
+      foreach (string extension in extensions)
+      {
+        string candidate = Path.Combine(dir, name + extension);
+        if (File.Exists(candidate))
+        {
+          return candidate;
+        }
+      }
+    }
+
+    // wsl.exe always resolves by name on Windows even when it is not on PATH.
+    if (isWindows && name.Equals("wsl.exe", StringComparison.OrdinalIgnoreCase))
+    {
+      return "wsl.exe";
+    }
+
+    // Podman Desktop does not always add podman to PATH; probe the well-known install locations.
+    if (name.Equals("podman", StringComparison.OrdinalIgnoreCase))
+    {
+      foreach (string candidate in KnownPodmanLocations())
+      {
+        if (File.Exists(candidate))
+        {
+          return candidate;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private static IEnumerable<string> KnownPodmanLocations()
+  {
+    yield return "/opt/homebrew/bin/podman";
+    yield return "/usr/local/bin/podman";
+
+    string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+    if (!string.IsNullOrEmpty(localAppData))
+    {
+      yield return Path.Combine(localAppData, "Programs", "Podman", "podman.exe");
+    }
+
+    string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+    if (!string.IsNullOrEmpty(programFiles))
+    {
+      yield return Path.Combine(programFiles, "RedHat", "Podman", "podman.exe");
+    }
+  }
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.3",
+  "version": "6.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main"
   ],


### PR DESCRIPTION
Fixes #282.

## Problem

The `IEventStore` implementations disagreed on the version number of a stream's first event:

| Store | Before |
|---|---|
| Azure Cosmos, EF Core, FileSystem | 0-based |
| InMemory | 1-based |
| MongoDB | 1-based |

Because `InMemory` was 1-based, it was **not a faithful test double** for Cosmos: code reasoning about absolute versions (e.g. "restore a soft-deleted entity to its pre-delete version") passed in InMemory-backed tests but produced corrupt aggregates in production on Cosmos.

A related problem: `EventRegistrationEventAggregator` could not aggregate *up to and including* version `0` — the creation event on 0-based stores — because of a `targetVersion > 0` guard.

## Changes

### Version alignment (fixes #282)
- **Aligned all stores to 0-based** (matching Cosmos/production). `InMemory` and `MongoDB` now number the first event `0`.
  - `MongoDB` gains a `NextVersion` field on its stream metadata (mirroring Cosmos/EF/FileSystem) so an empty stream is distinguishable from one holding only the creation event. Threaded through the store, stream and transactional batch.
  - `InMemory` numbers via a new `NextVersionUnlocked` helper; also wrapped the previously-unlocked low-level `AppendAsync` in the existing lock.
- **Aggregator can now target version 0.** The stop condition compares the event's own version (`evt.Version > targetVersion`) instead of the already-applied aggregate version, so `AggregateAsync(stream, 0, ct)` stops after the creation event instead of replaying the whole stream. Equivalent to the old behaviour for every previously-working case.
- Added regression tests (InMemory + MongoDB first-event-is-0; aggregator stop-at-0 and stop-at-N) and a **V6.4** changelog entry; bumped `version.json`.

### Podman-friendly integration tests
- Added `tests/Shared/TestcontainersRuntime.cs`, a module initializer linked into the MongoDB and Cosmos test projects. It auto-configures Testcontainers for **Podman on Windows (VS/WSL), Podman on macOS, and Docker on Linux (GitHub Actions)** without any manual environment variables. An existing `DOCKER_HOST` / Docker environment is left untouched, so CI behaviour is unchanged.

## Test results (all green)

Run locally against a Podman engine via the new auto-config (no manual env vars):

| Suite | Result | Runtime |
|---|---|---|
| Papst.EventStore.Tests (aggregator) | ✅ 56 | — |
| InMemory | ✅ 19 | — |
| EF Core | ✅ 8 | — |
| FileSystem | ✅ 8 | — |
| CodeGeneration | ✅ 20 | — |
| MongoDB | ✅ 19 | Testcontainers |
| Azure Cosmos | ✅ 13 | Testcontainers |

## Reviewer notes

- ⚠️ **Breaking for MongoDB persisted data.** Streams created with an earlier version are 1-based and their metadata lacks `NextVersion` (deserializes to `0`), so they must be migrated or recreated before appending further events. Called out in the changelog. InMemory is not persisted, so it has no migration concern.