### PR TITLE
[SKIP-CI] Bump Microsoft.* and test packages to latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
     <ItemGroup>
         <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
         <PackageVersion Include="Azure.Core" Version="1.53.0" />
-        <PackageVersion Include="Azure.Identity" Version="[1.15.0, 2.0]" />
-        <PackageVersion Include="coverlet.collector" Version="8.0.1">
+        <PackageVersion Include="Azure.Identity" Version="[1.17.1, 2.0]" />
+        <PackageVersion Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageVersion>
@@ -21,23 +21,23 @@
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageVersion>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
         <PackageVersion Include="MongoDB.Driver" Version="3.8.1" />
         <PackageVersion Include="Moq" Version="4.20.72" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
@@ -47,11 +47,11 @@
         <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
         <PackageVersion Include="System.Formats.Asn1" Version="10.0.1" />
         <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
-        <PackageVersion Include="Testcontainers" Version="4.11.0" />
-        <PackageVersion Include="Testcontainers.CosmosDb" Version="4.11.0" />
-        <PackageVersion Include="Testcontainers.MongoDb" Version="4.11.0" />
+        <PackageVersion Include="Testcontainers" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.CosmosDb" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.MongoDb" Version="4.14.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageVersion>


### PR DESCRIPTION
## Summary
- Bump `Microsoft.EntityFrameworkCore.*` and `Microsoft.Extensions.*` packages from `10.0.5` to the latest 10.x release, `10.0.11`.
- Bump test-related packages: `Microsoft.NET.Test.Sdk` (18.4.0 → 18.9.0), `Testcontainers`/`Testcontainers.CosmosDb`/`Testcontainers.MongoDb` (4.11.0 → 4.14.0), `coverlet.collector` (8.0.1 → 10.0.1), `xunit.runner.visualstudio` (3.1.5 → 4.0.0).
- Raise the `Azure.Identity` central version floor from `1.15.0` to `1.17.1`, required because `Microsoft.EntityFrameworkCore.SqlServer` 10.0.11 now pulls `Microsoft.Data.SqlClient 6.1.6`, which needs `Azure.Identity >= 1.17.1`.

## Test plan
- [x] `dotnet build Papst.EventStore.slnx -c Release` — succeeds, 0 errors
- [x] `dotnet test` on all non-MongoDB test projects — 124/124 passing (MongoDB integration tests can't run on this host due to a Testcontainers/Podman kernel incompatibility)