### PR TITLE
Add opt-in attribute-based event aggregation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
         <PackageVersion Include="MongoDB.Driver" Version="3.8.1" />
         <PackageVersion Include="Moq" Version="4.20.72" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageVersion Include="Papst.EventStore" Version="[6.4.0,7.0)" />
+        <PackageVersion Include="Papst.EventStore" Version="[7.0.0,8.0)" />
         <PackageVersion Include="SharpCompress" Version="0.48.1" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />

--- a/README.md
+++ b/README.md
@@ -52,6 +52,72 @@ Writing `MyEventsourcingEvent` to the Event Stream, will serialize them and name
 
 Note: `IsWriteName` is true by default!
 
+## Attribute-based Event Aggregation
+
+In addition to hand-written aggregators (deriving from `EventAggregatorBase<TEntity, TEvent>`), the code
+generator can **generate the aggregator for you** from a single attribute on the event. This is **opt-in** and
+works **in parallel** with the classic API — you can mix generated and hand-written aggregators freely, and an
+event only gets a generated aggregator when it is annotated.
+
+Annotate an event with `[EventAggregation<TEntity>]`. The generator emits an `IEventAggregator<TEntity, TEvent>`
+that copies the event's properties onto the target entity by **matching property name**:
+
+```csharp
+[EventName<Order>("OrderShipped")]
+[EventAggregation<Order>]
+public sealed record OrderShippedEvent(
+  OrderStatus Status,
+  string DeliveryTrackingCode,
+  DateTimeOffset PickupDate,
+  DateTimeOffset EstimatedArrivalDate);
+```
+
+Every event property that has a settable, equally named property on the entity is assigned. As with any
+generated event, the event still needs an `EventName` for type resolution, and the generated aggregator is
+registered by the existing `AddCodeGeneratedEvents()` extension.
+
+### Null handling
+
+By default `null` event values are **skipped** (the existing entity value is kept). Set
+`SkipNullValues = false` on the attribute to always write the value (including `null`), or override the
+behaviour for a single property with `[SkipWhenNull(bool)]`:
+
+```csharp
+[EventAggregation<Order>(SkipNullValues = false)]
+public sealed record OrderContactChanged(
+  string? Email,                              // written even when null
+  [property: SkipWhenNull(true)] string? Note // kept when null
+);
+```
+
+### Nested targets via `PropertyPath`
+
+`PropertyPath` selects a nested object on the entity as the aggregation target (dot-separated). Intermediate
+`null` links are instantiated automatically:
+
+```csharp
+[EventAggregation<Order>(PropertyPath = nameof(Order.ShippingAddress))]
+public sealed record ShippingAddressSet(string? City, string? Zip);
+```
+
+### Dictionaries and collections
+
+When `PropertyPath` points at a dictionary or collection, mark the event property that identifies the entry.
+Missing entries are created and added (**upsert**):
+
+```csharp
+// Dictionary<string, OrderLine> Lines — upsert the entry under the given key
+[EventAggregation<Order>(PropertyPath = nameof(Order.Lines))]
+public sealed record LineUpserted([property: AggregationDictionaryKey] string Sku, int Quantity);
+
+// List<OrderTag> Tags — upsert the item whose Id equals the event value
+[EventAggregation<Order>(PropertyPath = nameof(Order.Tags))]
+public sealed record TagUpserted([property: AggregationCollectionKey("Id")] string TagId, string? Label);
+```
+
+A working example lives in the Orders module of
+[`samples/SampleInMemoryAspNetApi/`](./samples/SampleInMemoryAspNetApi/) (`OrderShippedEvent`).
+
 ## Configuring an Implementation for use
 
 Please refer to the documentation in the relevant implementation sources:
@@ -170,6 +236,26 @@ A full working sample is available at [`samples/SampleEventCatalog/`](./samples/
 For an end-to-end ASP.NET Core example using the in-memory event store, stream aggregation, and read-model repositories, see [`samples/SampleInMemoryAspNetApi/`](./samples/SampleInMemoryAspNetApi/).
 
 # Changelog
+
+## V 7.0
+
+Adds an opt-in, attribute-based way to generate event aggregators, usable in parallel with the existing
+hand-written aggregator API.
+
+### Changes
+
+* New `[EventAggregation<TEntity>]` attribute on an event class/record makes the
+  `Papst.EventStore.CodeGeneration` source generator emit the aggregator and register it via
+  `AddCodeGeneratedEvents()`. Event properties are mapped onto the entity by name.
+* `PropertyPath` targets a nested object (intermediate `null` links are instantiated), a `Dictionary<,>`
+  (mark the key with `[AggregationDictionaryKey]`) or a collection (mark the search key with
+  `[AggregationCollectionKey("Id")]`); missing dictionary/collection items are upserted.
+* Null handling is controlled globally by `SkipNullValues` (default `true`) and per property by
+  `[SkipWhenNull(bool)]`.
+* If a hand-written aggregator already exists for the same `(entity, event)` pair, generation is skipped and
+  an `EVTSRC0003` diagnostic is reported, so the two approaches never double-register.
+* The code generator no longer fails when a project contains nested event/aggregator types; such types are
+  skipped by the (name-based) discovery instead.
 
 ## V 6.4
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ Every event property that has a settable, equally named property on the entity i
 generated event, the event still needs an `EventName` for type resolution, and the generated aggregator is
 registered by the existing `AddCodeGeneratedEvents()` extension.
 
+### Ignoring and renaming properties
+
+Use `[AggregationIgnore]` to exclude a property from aggregation, and `[AggregationProperty("TargetName")]` to
+map a property onto a differently named property on the entity:
+
+```csharp
+[EventAggregation<Order>]
+public sealed record OrderRenamed(
+  [property: AggregationProperty(nameof(Order.CustomerName))] string DisplayName, // written to Order.CustomerName
+  [property: AggregationIgnore] string CorrelationId                             // never mapped
+);
+```
+
 ### Null handling
 
 By default `null` event values are **skipped** (the existing entity value is kept). Set
@@ -252,6 +265,8 @@ hand-written aggregator API.
   `[AggregationCollectionKey("Id")]`); missing dictionary/collection items are upserted.
 * Null handling is controlled globally by `SkipNullValues` (default `true`) and per property by
   `[SkipWhenNull(bool)]`.
+* Individual event properties can be excluded with `[AggregationIgnore]` or mapped onto a differently named
+  entity property with `[AggregationProperty("TargetName")]`.
 * If a hand-written aggregator already exists for the same `(entity, event)` pair, generation is skipped and
   an `EVTSRC0003` diagnostic is reported, so the two approaches never double-register.
 * The code generator no longer fails when a project contains nested event/aggregator types; such types are

--- a/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Api/Contracts.cs
+++ b/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Api/Contracts.cs
@@ -9,5 +9,6 @@ public sealed record CreateOrderRequest(Guid UserId, List<CreateOrderItemRequest
 public sealed record CreateOrderItemRequest(string ProductName, int Quantity, decimal UnitPrice);
 public sealed record ChangeOrderStatusRequest(OrderStatus Status);
 public sealed record CancelOrderRequest(string Reason);
+public sealed record ShipOrderRequest(string DeliveryTrackingCode, DateTimeOffset PickupDate, DateTimeOffset EstimatedArrivalDate);
 public sealed record CatalogEventResponse(string EventName, string? Description, string[]? Constraints);
 public sealed record CatalogEventDetailsResponse(string EventName, string? Description, string[]? Constraints, string JsonSchema);

--- a/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Api/Program.cs
+++ b/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Api/Program.cs
@@ -37,6 +37,7 @@ app.MapGet("/", () => Results.Ok(new
     "GET /users/{userId}",
     "POST /orders",
     "POST /orders/{orderId}/status",
+    "POST /orders/{orderId}/ship",
     "POST /orders/{orderId}/cancel",
     "GET /orders/{orderId}",
     "GET /catalog/{entity}/events",
@@ -54,6 +55,7 @@ users.MapGet("/{userId:guid}", GetUserAsync);
 RouteGroupBuilder orders = app.MapGroup("/orders");
 orders.MapPost("/", CreateOrderAsync);
 orders.MapPost("/{orderId:guid}/status", ChangeOrderStatusAsync);
+orders.MapPost("/{orderId:guid}/ship", ShipOrderAsync);
 orders.MapPost("/{orderId:guid}/cancel", CancelOrderAsync);
 orders.MapGet("/{orderId:guid}", GetOrderAsync);
 
@@ -192,6 +194,32 @@ static async Task<IResult> ChangeOrderStatusAsync(
   }
 
   await stream.AppendAsync(Guid.NewGuid(), new OrderStatusChangedEvent(request.Status), cancellationToken: cancellationToken);
+  Order? order = await AggregateAndStoreAsync(stream, aggregator, repository.UpsertAsync, cancellationToken);
+
+  return order is null
+    ? Results.Problem("Order aggregation returned no entity.")
+    : Results.Ok(order);
+}
+
+static async Task<IResult> ShipOrderAsync(
+  Guid orderId,
+  ShipOrderRequest request,
+  IEventStore eventStore,
+  IEventStreamAggregator<Order> aggregator,
+  IOrderRepository repository,
+  CancellationToken cancellationToken)
+{
+  IEventStream? stream = await TryGetStreamAsync(eventStore, orderId, cancellationToken);
+  if (stream is null)
+  {
+    return Results.NotFound();
+  }
+
+  // OrderShippedEvent is aggregated by the code-generated attribute aggregation (no hand-written aggregator).
+  await stream.AppendAsync(
+    Guid.NewGuid(),
+    new OrderShippedEvent(OrderStatus.Shipped, request.DeliveryTrackingCode, request.PickupDate, request.EstimatedArrivalDate),
+    cancellationToken: cancellationToken);
   Order? order = await AggregateAndStoreAsync(stream, aggregator, repository.UpsertAsync, cancellationToken);
 
   return order is null

--- a/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Orders/InMemoryOrderRepository.cs
+++ b/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Orders/InMemoryOrderRepository.cs
@@ -27,6 +27,9 @@ public sealed class InMemoryOrderRepository : IOrderRepository
       Total = order.Total,
       Status = order.Status,
       CancellationReason = order.CancellationReason,
+      DeliveryTrackingCode = order.DeliveryTrackingCode,
+      PickupDate = order.PickupDate,
+      EstimatedArrivalDate = order.EstimatedArrivalDate,
       Version = order.Version,
       Items = [.. order.Items]
     };

--- a/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Orders/Order.cs
+++ b/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Orders/Order.cs
@@ -10,6 +10,12 @@ public sealed class Order : IEntity
   public OrderStatus Status { get; set; }
   public string? CancellationReason { get; set; }
   public List<OrderItem> Items { get; set; } = [];
+
+  // Shipping information, populated by the attribute-aggregated OrderShippedEvent.
+  public string? DeliveryTrackingCode { get; set; }
+  public DateTimeOffset? PickupDate { get; set; }
+  public DateTimeOffset? EstimatedArrivalDate { get; set; }
+
   public ulong Version { get; set; }
 }
 

--- a/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Orders/OrderEvents.cs
+++ b/samples/SampleInMemoryAspNetApi/SampleInMemoryAspNetApi.Orders/OrderEvents.cs
@@ -10,3 +10,14 @@ public sealed record OrderStatusChangedEvent(OrderStatus Status);
 
 [EventName<Order>("OrderCancelled")]
 public sealed record OrderCancelledEvent(string Reason);
+
+// Uses the attribute-based aggregation: no hand-written aggregator is required. The source generator maps the
+// event properties onto the equally named Order properties (Status, DeliveryTrackingCode, PickupDate,
+// EstimatedArrivalDate).
+[EventName<Order>("OrderShipped")]
+[EventAggregation<Order>]
+public sealed record OrderShippedEvent(
+  OrderStatus Status,
+  string DeliveryTrackingCode,
+  DateTimeOffset PickupDate,
+  DateTimeOffset EstimatedArrivalDate);

--- a/src/Papst.EventStore.Aggregation.EventRegistration/AggregationCollectionKeyAttribute.cs
+++ b/src/Papst.EventStore.Aggregation.EventRegistration/AggregationCollectionKeyAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Papst.EventStore.Aggregation.EventRegistration;
+
+/// <summary>
+/// Marks an Event property as the search criteria within the collection located at the
+/// <see cref="EventAggregationAttribute{TEntity}.PropertyPath"/>. During aggregation the item whose
+/// <see cref="TargetPropertyName"/> equals this Event property's value is updated with the Event's remaining
+/// properties; when no matching item exists a new item is created, its key property is set and the item is
+/// added to the collection (upsert).
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class AggregationCollectionKeyAttribute : Attribute
+{
+  /// <summary>
+  /// Name of the property on the collection's item type that is compared against this Event property's value.
+  /// </summary>
+  public string TargetPropertyName { get; }
+
+  /// <summary>
+  /// Marks the property as the collection search key.
+  /// </summary>
+  /// <param name="targetPropertyName">The item property to match against (e.g. <c>"Id"</c>).</param>
+  public AggregationCollectionKeyAttribute(string targetPropertyName) => TargetPropertyName = targetPropertyName;
+}

--- a/src/Papst.EventStore.Aggregation.EventRegistration/AggregationDictionaryKeyAttribute.cs
+++ b/src/Papst.EventStore.Aggregation.EventRegistration/AggregationDictionaryKeyAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Papst.EventStore.Aggregation.EventRegistration;
+
+/// <summary>
+/// Marks an Event property as the key into the dictionary located at the
+/// <see cref="EventAggregationAttribute{TEntity}.PropertyPath"/>. During aggregation the entry stored under
+/// this key is updated with the Event's remaining properties; when no entry exists a new value is created and
+/// inserted (upsert).
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class AggregationDictionaryKeyAttribute : Attribute
+{
+}

--- a/src/Papst.EventStore.Aggregation.EventRegistration/AggregationIgnoreAttribute.cs
+++ b/src/Papst.EventStore.Aggregation.EventRegistration/AggregationIgnoreAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Papst.EventStore.Aggregation.EventRegistration;
+
+/// <summary>
+/// Excludes an Event property from code-generated aggregation. The property is never mapped onto the target
+/// entity, even when an equally named target property exists.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class AggregationIgnoreAttribute : Attribute
+{
+}

--- a/src/Papst.EventStore.Aggregation.EventRegistration/AggregationPropertyAttribute.cs
+++ b/src/Papst.EventStore.Aggregation.EventRegistration/AggregationPropertyAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Papst.EventStore.Aggregation.EventRegistration;
+
+/// <summary>
+/// Maps an Event property to a differently named property on the target entity during code-generated
+/// aggregation. Without this attribute the Event property is mapped onto the equally named target property.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class AggregationPropertyAttribute : Attribute
+{
+  /// <summary>
+  /// Name of the property on the target entity (or the object addressed by
+  /// <see cref="EventAggregationAttribute{TEntity}.PropertyPath"/>) that this Event property is written to.
+  /// </summary>
+  public string TargetPropertyName { get; }
+
+  /// <summary>
+  /// Maps the property to the given target property name.
+  /// </summary>
+  /// <param name="targetPropertyName">The target entity property to write to.</param>
+  public AggregationPropertyAttribute(string targetPropertyName) => TargetPropertyName = targetPropertyName;
+}

--- a/src/Papst.EventStore.Aggregation.EventRegistration/EventAggregationAttribute.cs
+++ b/src/Papst.EventStore.Aggregation.EventRegistration/EventAggregationAttribute.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Papst.EventStore.Aggregation.EventRegistration;
+
+/// <summary>
+/// Opt-in marker that declares the complete aggregation instruction for an Event.
+/// When an Event Class or Record is decorated with this attribute, the
+/// <c>Papst.EventStore.CodeGeneration</c> source generator emits an
+/// <see cref="EventAggregatorBase{TEntity,TEvent}"/> implementation that copies the Event's
+/// properties onto <typeparamref name="TEntity"/> (or a nested target selected via <see cref="PropertyPath"/>)
+/// and registers it in the <c>AddCodeGeneratedEvents</c> DI extension.
+/// This runs in parallel with hand-written aggregators; it does not replace them.
+/// </summary>
+/// <typeparam name="TEntity">The Entity the Event shall be aggregated on</typeparam>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+public sealed class EventAggregationAttribute<TEntity> : Attribute
+  where TEntity : class
+{
+  /// <summary>
+  /// Dot-separated path from <typeparamref name="TEntity"/> to the object that shall receive the Event's
+  /// values. An empty string (the default) targets the Entity itself.
+  /// When the path resolves to a <see cref="System.Collections.Generic.IDictionary{TKey,TValue}"/> the Event
+  /// property marked with <see cref="AggregationDictionaryKeyAttribute"/> selects the entry to update;
+  /// when it resolves to a collection the Event property marked with
+  /// <see cref="AggregationCollectionKeyAttribute"/> selects the item to update.
+  /// </summary>
+  public string PropertyPath { get; set; } = string.Empty;
+
+  /// <summary>
+  /// Global flag controlling whether <see langword="null"/> Event values are skipped (default <see langword="true"/>)
+  /// or written onto the target. Can be overridden per property with <see cref="SkipWhenNullAttribute"/>.
+  /// </summary>
+  public bool SkipNullValues { get; set; } = true;
+}

--- a/src/Papst.EventStore.Aggregation.EventRegistration/SkipWhenNullAttribute.cs
+++ b/src/Papst.EventStore.Aggregation.EventRegistration/SkipWhenNullAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Papst.EventStore.Aggregation.EventRegistration;
+
+/// <summary>
+/// Overrides the <see cref="EventAggregationAttribute{TEntity}.SkipNullValues"/> setting for a single Event
+/// property during code-generated aggregation.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class SkipWhenNullAttribute : Attribute
+{
+  /// <summary>
+  /// When <see langword="true"/> the property is only written onto the target when its Event value is not
+  /// <see langword="null"/>. When <see langword="false"/> the property is always written, even when
+  /// <see langword="null"/>.
+  /// </summary>
+  public bool SkipWhenNull { get; }
+
+  /// <summary>
+  /// Marks the property with an explicit skip-when-null behaviour, overriding the Event's global setting.
+  /// </summary>
+  /// <param name="skipWhenNull">Whether <see langword="null"/> values shall be skipped for this property.</param>
+  public SkipWhenNullAttribute(bool skipWhenNull) => SkipWhenNull = skipWhenNull;
+}

--- a/src/Papst.EventStore.CodeGeneration/EventRegistrationIncrementalCodeGenerator.Aggregation.cs
+++ b/src/Papst.EventStore.CodeGeneration/EventRegistrationIncrementalCodeGenerator.Aggregation.cs
@@ -17,6 +17,8 @@ namespace Papst.EventStore.CodeGeneration
     private const string SkipWhenNullAttributeName = "SkipWhenNullAttribute";
     private const string DictionaryKeyAttributeName = "AggregationDictionaryKeyAttribute";
     private const string CollectionKeyAttributeName = "AggregationCollectionKeyAttribute";
+    private const string IgnoreAttributeName = "AggregationIgnoreAttribute";
+    private const string AggregationPropertyAttributeName = "AggregationPropertyAttribute";
 
     private const string IEnumerableOpen = "System.Collections.Generic.IEnumerable<T>";
     private const string IDictionaryOpen = "System.Collections.Generic.IDictionary<TKey, TValue>";
@@ -204,12 +206,21 @@ namespace Papst.EventStore.CodeGeneration
         {
           continue;
         }
-        if (targetIsRootEntity && evtProp.Name == "Version")
+        if (HasAttribute(evtProp, IgnoreAttributeName))
+        {
+          // explicitly excluded from aggregation
+          continue;
+        }
+
+        // resolve the target property name (may be remapped via [AggregationProperty])
+        string targetName = GetCtorString(evtProp, AggregationPropertyAttributeName) ?? evtProp.Name;
+
+        if (targetIsRootEntity && targetName == "Version")
         {
           // Version is maintained by the stream aggregator
           continue;
         }
-        if (!targetProps.TryGetValue(evtProp.Name, out var targetProp))
+        if (!targetProps.TryGetValue(targetName, out var targetProp))
         {
           continue;
         }
@@ -317,7 +328,8 @@ namespace Papst.EventStore.CodeGeneration
       }
 
       bool skip = EffectiveSkip(evtProp, skipNullValues);
-      string name = evtProp.Name;
+      string src = evtProp.Name;      // Event property (right-hand side)
+      string tgt = targetProp.Name;   // target entity property (left-hand side), possibly remapped
       bool targetIsNullableValue = targetProp.Type.IsValueType
         && targetProp.Type is INamedTypeSymbol tnt
         && tnt.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
@@ -325,29 +337,29 @@ namespace Papst.EventStore.CodeGeneration
       // non-nullable value type on the Event: never null
       if (evtProp.Type.IsValueType && !evtNullableValue)
       {
-        return $"    target.{name} = evt.{name};\n";
+        return $"    target.{tgt} = evt.{src};\n";
       }
 
       // reference type on the Event
       if (evtProp.Type.IsReferenceType)
       {
         return skip
-          ? $"    if (evt.{name} is not null) {{ target.{name} = evt.{name}; }}\n"
-          : $"    target.{name} = evt.{name};\n";
+          ? $"    if (evt.{src} is not null) {{ target.{tgt} = evt.{src}; }}\n"
+          : $"    target.{tgt} = evt.{src};\n";
       }
 
       // nullable value type (T?) on the Event
       if (targetIsNullableValue)
       {
         return skip
-          ? $"    if (evt.{name}.HasValue) {{ target.{name} = evt.{name}; }}\n"
-          : $"    target.{name} = evt.{name};\n";
+          ? $"    if (evt.{src}.HasValue) {{ target.{tgt} = evt.{src}; }}\n"
+          : $"    target.{tgt} = evt.{src};\n";
       }
 
       // nullable value on Event -> non-nullable value on target
       return skip
-        ? $"    if (evt.{name}.HasValue) {{ target.{name} = evt.{name}.Value; }}\n"
-        : $"    target.{name} = evt.{name}.GetValueOrDefault();\n";
+        ? $"    if (evt.{src}.HasValue) {{ target.{tgt} = evt.{src}.Value; }}\n"
+        : $"    target.{tgt} = evt.{src}.GetValueOrDefault();\n";
     }
 
     private static bool EffectiveSkip(IPropertySymbol evtProp, bool globalSkip)

--- a/src/Papst.EventStore.CodeGeneration/EventRegistrationIncrementalCodeGenerator.Aggregation.cs
+++ b/src/Papst.EventStore.CodeGeneration/EventRegistrationIncrementalCodeGenerator.Aggregation.cs
@@ -1,0 +1,505 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Papst.EventStore.CodeGeneration
+{
+  /// <summary>
+  /// Attribute based aggregation: discovers Events marked with <c>[EventAggregation&lt;TEntity&gt;]</c> and
+  /// emits an <c>EventAggregatorBase&lt;TEntity,TEvent&gt;</c> implementation per Event together with its DI
+  /// registration. The generated classes are written to a separate <c>EventAggregators.g.cs</c> file.
+  /// </summary>
+  public partial class EventRegistrationIncrementalCodeGenerator
+  {
+    private const string EventAggregationAttributeName = "EventAggregationAttribute";
+    private const string SkipWhenNullAttributeName = "SkipWhenNullAttribute";
+    private const string DictionaryKeyAttributeName = "AggregationDictionaryKeyAttribute";
+    private const string CollectionKeyAttributeName = "AggregationCollectionKeyAttribute";
+
+    private const string IEnumerableOpen = "System.Collections.Generic.IEnumerable<T>";
+    private const string IDictionaryOpen = "System.Collections.Generic.IDictionary<TKey, TValue>";
+    private const string ICollectionOpen = "System.Collections.Generic.ICollection<T>";
+
+    private static readonly SymbolDisplayFormat FqFormat = SymbolDisplayFormat.FullyQualifiedFormat;
+
+    private sealed class GeneratedAggregatorInfo
+    {
+      public string EntityFullName { get; set; }
+      public string EventFullName { get; set; }
+      public string GeneratedClassName { get; set; }
+      public string MethodBody { get; set; }
+
+      /// <summary>Namespace-qualified pair key (without <c>global::</c>) used for conflict detection.</summary>
+      public string PairKey { get; set; }
+    }
+
+    /// <summary>
+    /// Scans all type declarations for <c>[EventAggregation&lt;TEntity&gt;]</c> attributes and builds the
+    /// aggregator descriptors. Conflicts with hand written aggregators (<paramref name="manualPairs"/>) are
+    /// skipped and reported as <c>EVTSRC0003</c>.
+    /// </summary>
+    private static List<GeneratedAggregatorInfo> BuildGeneratedAggregators(
+      Compilation compilation,
+      TypeDeclarationSyntax[] allClasses,
+      HashSet<string> manualPairs,
+      SourceProductionContext productionContext)
+    {
+      var result = new List<GeneratedAggregatorInfo>();
+      var seenPairs = new HashSet<string>();
+
+      foreach (var decl in allClasses)
+      {
+        var model = compilation.GetSemanticModel(decl.SyntaxTree);
+        if (model.GetDeclaredSymbol(decl, productionContext.CancellationToken) is not INamedTypeSymbol eventSymbol)
+        {
+          continue;
+        }
+
+        foreach (var attr in eventSymbol.GetAttributes())
+        {
+          var attrClass = attr.AttributeClass;
+          if (attrClass == null
+              || attrClass.Name != EventAggregationAttributeName
+              || !attrClass.IsGenericType
+              || attrClass.TypeArguments.Length != 1)
+          {
+            continue;
+          }
+
+          if (attrClass.TypeArguments[0] is not INamedTypeSymbol entitySymbol)
+          {
+            continue;
+          }
+
+          string pairKey = $"{entitySymbol.ToDisplayString()}|{eventSymbol.ToDisplayString()}";
+
+          if (manualPairs.Contains(pairKey))
+          {
+            ReportInfo(productionContext, "EVTSRC0003",
+              "Generated aggregator skipped due to existing aggregator",
+              $"An aggregator for Entity '{entitySymbol.Name}' and Event '{eventSymbol.Name}' already exists; the generated aggregator is skipped.");
+            continue;
+          }
+
+          if (!seenPairs.Add(pairKey))
+          {
+            // only one generated aggregator per (Entity, Event) pair
+            continue;
+          }
+
+          string propertyPath = GetNamedString(attr, "PropertyPath") ?? string.Empty;
+          bool skipNullValues = GetNamedBool(attr, "SkipNullValues") ?? true;
+
+          if (TryBuildAggregator(productionContext, eventSymbol, entitySymbol, propertyPath, skipNullValues, out var info))
+          {
+            info.PairKey = pairKey;
+            result.Add(info);
+          }
+        }
+      }
+
+      return result;
+    }
+
+    private static bool TryBuildAggregator(
+      SourceProductionContext ctx,
+      INamedTypeSymbol eventSymbol,
+      INamedTypeSymbol entitySymbol,
+      string propertyPath,
+      bool skipNullValues,
+      out GeneratedAggregatorInfo info)
+    {
+      info = null;
+
+      string entityFull = eventSafeFq(entitySymbol);
+      string eventFull = eventSafeFq(eventSymbol);
+
+      var eventProps = GetPublicReadableProperties(eventSymbol).ToList();
+
+      // Determine key properties (dictionary / collection) declared on the Event
+      IPropertySymbol dictKeyProp = eventProps.FirstOrDefault(p => HasAttribute(p, DictionaryKeyAttributeName));
+      IPropertySymbol collectionKeyProp = eventProps.FirstOrDefault(p => HasAttribute(p, CollectionKeyAttributeName));
+      string collectionTargetName = collectionKeyProp == null
+        ? null
+        : GetCtorString(collectionKeyProp, CollectionKeyAttributeName);
+
+      var body = new StringBuilder();
+      ITypeSymbol targetType;
+
+      // --- Resolve the base object addressed by PropertyPath (instantiating intermediate null links) ---
+      if (!TryResolvePath(ctx, entitySymbol, propertyPath, body, out ITypeSymbol pathType, out string pathExpr, out IPropertySymbol finalProp))
+      {
+        return false;
+      }
+
+      if (dictKeyProp != null)
+      {
+        var dictIface = FindConstructedInterface(pathType, IDictionaryOpen);
+        if (dictIface == null)
+        {
+          ReportWarning(ctx, "EVTSRC0004", "Invalid aggregation target",
+            $"PropertyPath '{propertyPath}' on Event '{eventSymbol.Name}' is marked with a dictionary key but does not resolve to IDictionary<,>.");
+          return false;
+        }
+        ITypeSymbol keyType = dictIface.TypeArguments[0];
+        targetType = dictIface.TypeArguments[1];
+        EmitDictionaryNullInit(body, pathExpr, keyType, targetType);
+        body.AppendLine($"    if (!{pathExpr}.TryGetValue(evt.{dictKeyProp.Name}, out var target))");
+        body.AppendLine("    {");
+        body.AppendLine($"      target = new {eventSafeFq(targetType)}();");
+        body.AppendLine($"      {pathExpr}[evt.{dictKeyProp.Name}] = target;");
+        body.AppendLine("    }");
+      }
+      else if (collectionKeyProp != null)
+      {
+        var collIface = FindConstructedInterface(pathType, ICollectionOpen);
+        if (collIface == null)
+        {
+          ReportWarning(ctx, "EVTSRC0004", "Invalid aggregation target",
+            $"PropertyPath '{propertyPath}' on Event '{eventSymbol.Name}' is marked with a collection key but does not resolve to ICollection<T>.");
+          return false;
+        }
+        targetType = collIface.TypeArguments[0];
+        EmitCollectionNullInit(body, pathExpr, targetType);
+        body.AppendLine($"    var target = global::System.Linq.Enumerable.FirstOrDefault({pathExpr}, x => global::System.Collections.Generic.EqualityComparer<{eventSafeFq(collectionKeyProp.Type)}>.Default.Equals(x.{collectionTargetName}, evt.{collectionKeyProp.Name}));");
+        body.AppendLine("    if (target is null)");
+        body.AppendLine("    {");
+        body.AppendLine($"      target = new {eventSafeFq(targetType)}();");
+        // set the key property on the new item so it is found on subsequent events
+        var keySetter = GetPublicSettableProperties(targetType).FirstOrDefault(p => p.Name == collectionTargetName);
+        if (keySetter != null)
+        {
+          body.AppendLine($"      target.{collectionTargetName} = evt.{collectionKeyProp.Name};");
+        }
+        body.AppendLine($"      {pathExpr}.Add(target);");
+        body.AppendLine("    }");
+      }
+      else
+      {
+        targetType = pathType;
+        // instantiate the final object when it is a settable reference type with a parameterless constructor
+        if (finalProp != null && CanInstantiate(finalProp))
+        {
+          body.AppendLine($"    {pathExpr} ??= new {eventSafeFq(pathType)}();");
+        }
+        body.AppendLine($"    var target = {pathExpr};");
+      }
+
+      // --- Emit property assignments ---
+      var targetProps = GetPublicSettableProperties(targetType)
+        .GroupBy(p => p.Name)
+        .ToDictionary(g => g.Key, g => g.First());
+
+      var keyPropNames = new HashSet<string>();
+      if (dictKeyProp != null) keyPropNames.Add(dictKeyProp.Name);
+      if (collectionKeyProp != null) keyPropNames.Add(collectionKeyProp.Name);
+
+      bool targetIsRootEntity = SymbolEqualityComparer.Default.Equals(targetType, entitySymbol);
+
+      foreach (var evtProp in eventProps)
+      {
+        if (keyPropNames.Contains(evtProp.Name))
+        {
+          continue;
+        }
+        if (targetIsRootEntity && evtProp.Name == "Version")
+        {
+          // Version is maintained by the stream aggregator
+          continue;
+        }
+        if (!targetProps.TryGetValue(evtProp.Name, out var targetProp))
+        {
+          continue;
+        }
+
+        string assignment = BuildAssignment(evtProp, targetProp, skipNullValues);
+        if (assignment != null)
+        {
+          body.Append(assignment);
+        }
+      }
+
+      info = new GeneratedAggregatorInfo
+      {
+        EntityFullName = entityFull,
+        EventFullName = eventFull,
+        GeneratedClassName = $"{eventSymbol.Name}_{entitySymbol.Name}_GeneratedAggregator",
+        MethodBody = body.ToString(),
+      };
+      return true;
+    }
+
+    /// <summary>
+    /// Resolves the <paramref name="propertyPath"/> from the entity, emitting null-instantiating navigation for
+    /// the intermediate links only. The final segment is left to the caller (single object / dictionary /
+    /// collection modes) so the correct concrete container type is instantiated. Returns the resolved type, the
+    /// C# expression addressing the final object (the entity itself for an empty path) and the final property.
+    /// </summary>
+    private static bool TryResolvePath(
+      SourceProductionContext ctx,
+      INamedTypeSymbol entitySymbol,
+      string propertyPath,
+      StringBuilder body,
+      out ITypeSymbol finalType,
+      out string finalExpr,
+      out IPropertySymbol finalProp)
+    {
+      finalType = entitySymbol;
+      finalExpr = "entity";
+      finalProp = null;
+
+      if (string.IsNullOrWhiteSpace(propertyPath))
+      {
+        return true;
+      }
+
+      ITypeSymbol current = entitySymbol;
+      string expr = "entity";
+      var chain = new List<(IPropertySymbol prop, string expr)>();
+      foreach (string rawSegment in propertyPath.Split('.'))
+      {
+        string segment = rawSegment.Trim();
+        if (segment.Length == 0)
+        {
+          continue;
+        }
+
+        var prop = GetPublicReadableProperties(current).FirstOrDefault(p => p.Name == segment);
+        if (prop == null)
+        {
+          ReportWarning(ctx, "EVTSRC0004", "Invalid aggregation target",
+            $"PropertyPath segment '{segment}' was not found on type '{current.Name}'.");
+          return false;
+        }
+
+        expr = $"{expr}.{prop.Name}";
+        chain.Add((prop, expr));
+        current = prop.Type;
+      }
+
+      if (chain.Count == 0)
+      {
+        return true;
+      }
+
+      // instantiate intermediate links only; the final container is instantiated by the caller
+      for (int i = 0; i < chain.Count - 1; i++)
+      {
+        if (CanInstantiate(chain[i].prop))
+        {
+          body.AppendLine($"    {chain[i].expr} ??= new {eventSafeFq(chain[i].prop.Type)}();");
+        }
+      }
+
+      finalType = current;
+      finalExpr = expr;
+      finalProp = chain[chain.Count - 1].prop;
+      return true;
+    }
+
+    private static bool CanInstantiate(IPropertySymbol prop)
+      => prop.SetMethod != null
+         && !prop.SetMethod.IsInitOnly
+         && prop.Type.IsReferenceType
+         && HasParameterlessCtor(prop.Type);
+
+    private static string BuildAssignment(IPropertySymbol evtProp, IPropertySymbol targetProp, bool skipNullValues)
+    {
+      var (evtUnderlying, evtNullableValue) = Unwrap(evtProp.Type);
+      var (targetUnderlying, _) = Unwrap(targetProp.Type);
+
+      // only map when the underlying types match to keep the generated code valid
+      if (evtUnderlying.ToDisplayString(FqFormat) != targetUnderlying.ToDisplayString(FqFormat))
+      {
+        return null;
+      }
+
+      bool skip = EffectiveSkip(evtProp, skipNullValues);
+      string name = evtProp.Name;
+      bool targetIsNullableValue = targetProp.Type.IsValueType
+        && targetProp.Type is INamedTypeSymbol tnt
+        && tnt.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
+
+      // non-nullable value type on the Event: never null
+      if (evtProp.Type.IsValueType && !evtNullableValue)
+      {
+        return $"    target.{name} = evt.{name};\n";
+      }
+
+      // reference type on the Event
+      if (evtProp.Type.IsReferenceType)
+      {
+        return skip
+          ? $"    if (evt.{name} is not null) {{ target.{name} = evt.{name}; }}\n"
+          : $"    target.{name} = evt.{name};\n";
+      }
+
+      // nullable value type (T?) on the Event
+      if (targetIsNullableValue)
+      {
+        return skip
+          ? $"    if (evt.{name}.HasValue) {{ target.{name} = evt.{name}; }}\n"
+          : $"    target.{name} = evt.{name};\n";
+      }
+
+      // nullable value on Event -> non-nullable value on target
+      return skip
+        ? $"    if (evt.{name}.HasValue) {{ target.{name} = evt.{name}.Value; }}\n"
+        : $"    target.{name} = evt.{name}.GetValueOrDefault();\n";
+    }
+
+    private static bool EffectiveSkip(IPropertySymbol evtProp, bool globalSkip)
+    {
+      var attr = evtProp.GetAttributes().FirstOrDefault(a => a.AttributeClass?.Name == SkipWhenNullAttributeName);
+      if (attr != null && attr.ConstructorArguments.Length == 1 && attr.ConstructorArguments[0].Value is bool b)
+      {
+        return b;
+      }
+      return globalSkip;
+    }
+
+    /// <summary>Builds the <c>EventAggregators.g.cs</c> file text.</summary>
+    private static string BuildGeneratedAggregatorsFile(string baseNamespace, List<GeneratedAggregatorInfo> generated)
+    {
+      var builder = new StringBuilder();
+      builder
+        .AppendLine("/// <auto-generated>")
+        .AppendLine("///  This code was generated Papst.EventStore.CodeGeneration")
+        .AppendLine("///  See https://github.com/PapstIO/Papst.EventStore for more information")
+        .AppendLine("/// </auto-generated>")
+        .AppendLine("#nullable enable")
+        .AppendLine($"namespace {baseNamespace}")
+        .AppendLine("{");
+
+      foreach (var info in generated)
+      {
+        builder
+          .AppendLine($"  internal sealed class {info.GeneratedClassName} : global::Papst.EventStore.Aggregation.EventAggregatorBase<{info.EntityFullName}, {info.EventFullName}>")
+          .AppendLine("  {")
+          .AppendLine($"    public override global::System.Threading.Tasks.ValueTask<{info.EntityFullName}?> ApplyAsync({info.EventFullName} evt, {info.EntityFullName} entity, global::Papst.EventStore.IAggregatorStreamContext ctx)")
+          .AppendLine("    {")
+          .Append(info.MethodBody)
+          .AppendLine("    return AsTask(entity);")
+          .AppendLine("    }")
+          .AppendLine("  }");
+      }
+
+      builder.AppendLine("}");
+      return builder.ToString();
+    }
+
+    #region symbol helpers
+
+    private static IEnumerable<IPropertySymbol> GetPublicReadableProperties(ITypeSymbol type)
+    {
+      var seen = new HashSet<string>();
+      for (ITypeSymbol current = type; current != null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+      {
+        foreach (var prop in current.GetMembers().OfType<IPropertySymbol>())
+        {
+          if (prop.DeclaredAccessibility == Accessibility.Public
+              && !prop.IsStatic
+              && !prop.IsIndexer
+              && prop.GetMethod != null
+              && seen.Add(prop.Name))
+          {
+            yield return prop;
+          }
+        }
+      }
+    }
+
+    private static IEnumerable<IPropertySymbol> GetPublicSettableProperties(ITypeSymbol type)
+    {
+      var seen = new HashSet<string>();
+      for (ITypeSymbol current = type; current != null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+      {
+        foreach (var prop in current.GetMembers().OfType<IPropertySymbol>())
+        {
+          if (prop.DeclaredAccessibility == Accessibility.Public
+              && !prop.IsStatic
+              && !prop.IsIndexer
+              && prop.SetMethod != null
+              && !prop.SetMethod.IsInitOnly
+              && prop.SetMethod.DeclaredAccessibility == Accessibility.Public
+              && seen.Add(prop.Name))
+          {
+            yield return prop;
+          }
+        }
+      }
+    }
+
+    private static bool HasAttribute(ISymbol symbol, string attributeName)
+      => symbol.GetAttributes().Any(a => a.AttributeClass?.Name == attributeName);
+
+    private static string GetCtorString(IPropertySymbol prop, string attributeName)
+    {
+      var attr = prop.GetAttributes().FirstOrDefault(a => a.AttributeClass?.Name == attributeName);
+      if (attr != null && attr.ConstructorArguments.Length == 1)
+      {
+        return attr.ConstructorArguments[0].Value as string;
+      }
+      return null;
+    }
+
+    private static string GetNamedString(AttributeData attr, string name)
+      => attr.NamedArguments.FirstOrDefault(a => a.Key == name).Value.Value as string;
+
+    private static bool? GetNamedBool(AttributeData attr, string name)
+    {
+      var arg = attr.NamedArguments.FirstOrDefault(a => a.Key == name);
+      if (arg.Key == name && arg.Value.Value is bool b)
+      {
+        return b;
+      }
+      return null;
+    }
+
+    private static (ITypeSymbol underlying, bool nullableValue) Unwrap(ITypeSymbol type)
+    {
+      if (type is INamedTypeSymbol nt && nt.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+      {
+        return (nt.TypeArguments[0], true);
+      }
+      return (type, false);
+    }
+
+    private static INamedTypeSymbol FindConstructedInterface(ITypeSymbol type, string openGenericDisplay)
+    {
+      if (type is INamedTypeSymbol named && named.IsGenericType
+          && named.OriginalDefinition.ToDisplayString() == openGenericDisplay)
+      {
+        return named;
+      }
+      return type.AllInterfaces.FirstOrDefault(i => i.OriginalDefinition.ToDisplayString() == openGenericDisplay);
+    }
+
+    private static bool HasParameterlessCtor(ITypeSymbol type)
+      => type is INamedTypeSymbol nt
+         && !nt.IsAbstract
+         && nt.InstanceConstructors.Any(c => c.Parameters.Length == 0 && c.DeclaredAccessibility != Accessibility.Private);
+
+    private static void EmitDictionaryNullInit(StringBuilder body, string expr, ITypeSymbol keyType, ITypeSymbol valueType)
+      => body.AppendLine($"    {expr} ??= new global::System.Collections.Generic.Dictionary<{eventSafeFq(keyType)}, {eventSafeFq(valueType)}>();");
+
+    private static void EmitCollectionNullInit(StringBuilder body, string expr, ITypeSymbol elementType)
+      => body.AppendLine($"    {expr} ??= new global::System.Collections.Generic.List<{eventSafeFq(elementType)}>();");
+
+    /// <summary>Fully-qualified type name (with <c>global::</c>), nullable annotations stripped.</summary>
+    private static string eventSafeFq(ITypeSymbol type)
+      => type.WithNullableAnnotation(NullableAnnotation.None).ToDisplayString(FqFormat);
+
+    private static void ReportInfo(SourceProductionContext ctx, string id, string title, string message)
+      => ctx.ReportDiagnostic(Diagnostic.Create(new DiagnosticDescriptor(
+        id, title, message, "EventRegistrationCodeGen", DiagnosticSeverity.Info, true), Location.None));
+
+    private static void ReportWarning(SourceProductionContext ctx, string id, string title, string message)
+      => ctx.ReportDiagnostic(Diagnostic.Create(new DiagnosticDescriptor(
+        id, title, message, "EventRegistrationCodeGen", DiagnosticSeverity.Warning, true), Location.None));
+
+    #endregion
+  }
+}

--- a/src/Papst.EventStore.CodeGeneration/EventRegistrationIncrementalCodeGenerator.cs
+++ b/src/Papst.EventStore.CodeGeneration/EventRegistrationIncrementalCodeGenerator.cs
@@ -12,7 +12,7 @@ namespace Papst.EventStore.CodeGeneration
   /// Incremental Source Generator equivalent to EventRegistrationCodeGenerator.
   /// </summary>
   [Generator]
-  public class EventRegistrationIncrementalCodeGenerator : IIncrementalGenerator
+  public partial class EventRegistrationIncrementalCodeGenerator : IIncrementalGenerator
   {
     private const string EventAggregatorBaseClassName = "EventAggregatorBase";
     private const string EventAggregatorInterfaceName = "IEventAggregator";
@@ -88,7 +88,11 @@ namespace Papst.EventStore.CodeGeneration
 
           var aggregators = allClasses
             .OfType<ClassDeclarationSyntax>()
-            .Where(c => c.DescendantNodes().OfType<SimpleBaseTypeSyntax>().Any(bt =>
+            // Only consider top-level classes and their OWN base list. DescendantNodes() is recursive and
+            // would otherwise pick up base types of nested aggregators (whose namespace/full name cannot be
+            // reconstructed from syntax), matching the wrong container.
+            .Where(c => !(c.Parent is TypeDeclarationSyntax))
+            .Where(c => OwnBaseTypes(c).Any(bt =>
               bt.Type is GenericNameSyntax &&
               (
                 ((GenericNameSyntax)bt.Type).Identifier.ValueText == EventAggregatorBaseClassName ||
@@ -99,10 +103,8 @@ namespace Papst.EventStore.CodeGeneration
             {
               Class = c.Identifier.ValueText,
               Namespace = FindNamespace(c),
-              TypeArguments = c
-                .DescendantNodes()
-                .OfType<SimpleBaseTypeSyntax>()
-                .Where(bt => ((GenericNameSyntax)bt.Type).Identifier.ValueText == EventAggregatorBaseClassName || ((GenericNameSyntax)bt.Type).Identifier.ValueText == EventAggregatorInterfaceName)
+              TypeArguments = OwnBaseTypes(c)
+                .Where(bt => bt.Type is GenericNameSyntax && (((GenericNameSyntax)bt.Type).Identifier.ValueText == EventAggregatorBaseClassName || ((GenericNameSyntax)bt.Type).Identifier.ValueText == EventAggregatorInterfaceName))
                 .Select(bt => new
                 {
                   BT = bt,
@@ -120,7 +122,13 @@ namespace Papst.EventStore.CodeGeneration
             })
             .ToList();
 
-          if (events.Count > 0 || aggregators.Count > 0)
+          // --- Attribute based aggregation: discover [EventAggregation<TEntity>] events ---
+          var manualPairs = new HashSet<string>(
+            aggregators.SelectMany(a => a.TypeArguments)
+              .Select(impl => $"{impl.EntityNamespace}.{impl.Entity}|{impl.EventNamespace}.{impl.Event}"));
+          var generatedAggregators = BuildGeneratedAggregators(compilation, allClasses, manualPairs, productionContext);
+
+          if (events.Count > 0 || aggregators.Count > 0 || generatedAggregators.Count > 0)
           {
             StringBuilder builder = new StringBuilder();
             builder
@@ -166,6 +174,14 @@ namespace Papst.EventStore.CodeGeneration
               }
             }
 
+            if (generatedAggregators.Count > 0)
+            {
+              foreach (var generated in generatedAggregators)
+              {
+                builder.AppendLine($"    services.AddTransient<global::Papst.EventStore.Aggregation.IEventAggregator<{generated.EntityFullName}, {generated.EventFullName}>, global::{baseNamespace}.{generated.GeneratedClassName}>();");
+              }
+            }
+
             builder
               .AppendLine("    if (!services.Any(descriptor => descriptor.ServiceType == typeof(Papst.EventStore.IEventTypeProvider)))")
               .AppendLine("    {")
@@ -185,6 +201,11 @@ namespace Papst.EventStore.CodeGeneration
             builder.AppendLine("}");
 
             productionContext.AddSource("EventRegistration.g.cs", builder.ToString());
+
+            if (generatedAggregators.Count > 0)
+            {
+              productionContext.AddSource("EventAggregators.g.cs", BuildGeneratedAggregatorsFile(baseNamespace, generatedAggregators));
+            }
           }
           else
           {
@@ -535,6 +556,13 @@ namespace Papst.EventStore.CodeGeneration
     /// </summary>
     private static EventInfo FindEvents(Compilation compilation, TypeDeclarationSyntax typeDeclaration, TypeDeclarationSyntax[] allClasses)
     {
+      // Nested types are not supported by the syntax-based name discovery (their namespace/full name
+      // cannot be reconstructed from the declaration alone); skip them rather than failing generation.
+      if (typeDeclaration.Parent is TypeDeclarationSyntax)
+      {
+        return null;
+      }
+
       var attributes = typeDeclaration.AttributeLists
         .SelectMany(x => x.Attributes)
         .Where(attr => IsEventNameAttribute(attr.Name))
@@ -768,6 +796,15 @@ namespace Papst.EventStore.CodeGeneration
     #endregion
 
     #region Namespace Helpers
+
+    /// <summary>
+    /// Returns the type's own base list entries (not descendants), so nested types' base lists are not
+    /// mistakenly attributed to their containing type.
+    /// </summary>
+    private static IEnumerable<SimpleBaseTypeSyntax> OwnBaseTypes(TypeDeclarationSyntax type)
+      => type.BaseList == null
+        ? Enumerable.Empty<SimpleBaseTypeSyntax>()
+        : type.BaseList.Types.OfType<SimpleBaseTypeSyntax>();
 
     private static string FindNamespace(TypeDeclarationSyntax typeDeclaration)
     {

--- a/src/Papst.EventStore.CodeGeneration/Papst.EventStore.CodeGeneration.csproj
+++ b/src/Papst.EventStore.CodeGeneration/Papst.EventStore.CodeGeneration.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>

--- a/tests/Papst.EventStore.CodeGeneration.Tests/EventAggregationGeneratorTests.cs
+++ b/tests/Papst.EventStore.CodeGeneration.Tests/EventAggregationGeneratorTests.cs
@@ -118,6 +118,41 @@ namespace TestApp
   }
 
   [Fact]
+  public void AggregationIgnore_ExcludesProperty()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>]
+    public record WithIgnored(string? Name, [property: AggregationIgnore] string? Nick);");
+
+    aggregators!.ShouldContain("if (evt.Name is not null) { target.Name = evt.Name; }");
+    aggregators!.ShouldNotContain("target.Nick");
+    aggregators!.ShouldNotContain("evt.Nick");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void AggregationProperty_RemapsTargetName()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>]
+    public record Renamed([property: AggregationProperty(nameof(Entity.Nick))] string? DisplayName);");
+
+    aggregators!.ShouldContain("if (evt.DisplayName is not null) { target.Nick = evt.DisplayName; }");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void AggregationProperty_RemapsValueTypeTarget()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>]
+    public record CountRenamed([property: AggregationProperty(nameof(Entity.Count))] int Amount);");
+
+    aggregators!.ShouldContain("target.Count = evt.Amount;");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
   public void NestedPropertyPath_NavigatesAndInstantiates()
   {
     var (aggregators, _, _, output) = Generate(@"

--- a/tests/Papst.EventStore.CodeGeneration.Tests/EventAggregationGeneratorTests.cs
+++ b/tests/Papst.EventStore.CodeGeneration.Tests/EventAggregationGeneratorTests.cs
@@ -1,0 +1,182 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Shouldly;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Papst.EventStore.CodeGeneration.Tests;
+
+public class EventAggregationGeneratorTests
+{
+  private const string Prelude = @"
+using System;
+using System.Collections.Generic;
+using Papst.EventStore.Aggregation;
+using Papst.EventStore.Aggregation.EventRegistration;
+
+namespace TestApp
+{
+  public class SubEntity { public string? Name2 { get; set; } }
+  public class Item { public Guid Id { get; set; } public string? Value { get; set; } }
+  public class Entity : Papst.EventStore.IEntity
+  {
+    public ulong Version { get; set; }
+    public string? Name { get; set; }
+    public string? Nick { get; set; }
+    public int Count { get; set; }
+    public SubEntity Child { get; set; } = new();
+    public Dictionary<Guid, Item> Items { get; set; } = new();
+    public List<Item> ItemsList { get; set; } = new();
+  }
+";
+
+  private static (string? aggregators, string? registration, GeneratorDriverRunResult run, Compilation output) Generate(string body)
+  {
+    Compilation input = CreateCompilation(Prelude + body + "\n}\n");
+    GeneratorDriver driver = CSharpGeneratorDriver.Create(new EventRegistrationIncrementalCodeGenerator());
+    driver = driver.RunGeneratorsAndUpdateCompilation(input, out Compilation output, out _);
+    GeneratorDriverRunResult run = driver.GetRunResult();
+
+    string? SourceFor(string hint) => run.Results[0].GeneratedSources
+      .Where(s => s.HintName == hint)
+      .Select(s => s.SourceText.ToString())
+      .FirstOrDefault();
+
+    return (SourceFor("EventAggregators.g.cs"), SourceFor("EventRegistration.g.cs"), run, output);
+  }
+
+  private static Compilation CreateCompilation(string source)
+  {
+    var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+      .Split(Path.PathSeparator)
+      .Where(p => p.Length > 0)
+      .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p));
+
+    return CSharpCompilation.Create("compilation",
+      new[] { CSharpSyntaxTree.ParseText(source) },
+      references,
+      new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+  }
+
+  private static void ShouldCompileClean(Compilation output)
+    => output.GetDiagnostics()
+        .Where(d => d.Severity == DiagnosticSeverity.Error)
+        .Select(d => d.ToString())
+        .ShouldBeEmpty();
+
+  [Fact]
+  public void GeneratesRootAggregator_WithSkipNullByDefault()
+  {
+    var (aggregators, registration, _, output) = Generate(@"
+    [EventAggregation<Entity>]
+    public record NameChanged(string? Name);");
+
+    aggregators!.ShouldNotBeNull();
+    aggregators!.ShouldContain("class NameChanged_Entity_GeneratedAggregator");
+    aggregators!.ShouldContain("var target = entity;");
+    aggregators!.ShouldContain("if (evt.Name is not null) { target.Name = evt.Name; }");
+    registration.ShouldNotBeNull();
+    registration!.ShouldContain("IEventAggregator<global::TestApp.Entity, global::TestApp.NameChanged>");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void SkipNullValuesFalse_AssignsUnconditionally()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>(SkipNullValues = false)]
+    public record NameForced(string? Name);");
+
+    aggregators!.ShouldContain("target.Name = evt.Name;");
+    aggregators!.ShouldNotContain("if (evt.Name is not null)");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void SkipWhenNullAttribute_OverridesGlobalSetting()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>]
+    public record Mixed(string? Name, [property: SkipWhenNull(false)] string? Nick);");
+
+    aggregators!.ShouldContain("if (evt.Name is not null) { target.Name = evt.Name; }");
+    aggregators!.ShouldContain("target.Nick = evt.Nick;");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void NonNullableValueType_IsAlwaysAssigned()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>]
+    public record CountSet(int Count);");
+
+    aggregators!.ShouldContain("target.Count = evt.Count;");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void NestedPropertyPath_NavigatesAndInstantiates()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>(PropertyPath = nameof(Entity.Child))]
+    public record ChildRenamed(string? Name2);");
+
+    aggregators!.ShouldContain("entity.Child ??= new global::TestApp.SubEntity();");
+    aggregators!.ShouldContain("var target = entity.Child;");
+    aggregators!.ShouldContain("if (evt.Name2 is not null) { target.Name2 = evt.Name2; }");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void DictionaryPropertyPath_UpsertsByKey()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>(PropertyPath = nameof(Entity.Items))]
+    public record ItemUpdated([property: AggregationDictionaryKey] Guid Id, string? Value);");
+
+    aggregators!.ShouldContain("entity.Items ??= new global::System.Collections.Generic.Dictionary<global::System.Guid, global::TestApp.Item>();");
+    aggregators!.ShouldContain("if (!entity.Items.TryGetValue(evt.Id, out var target))");
+    aggregators!.ShouldContain("entity.Items[evt.Id] = target;");
+    aggregators!.ShouldContain("if (evt.Value is not null) { target.Value = evt.Value; }");
+    // the key property must not be mapped as a normal value
+    aggregators!.ShouldNotContain("target.Id = evt.Id;");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void CollectionPropertyPath_UpsertsBySearchKey()
+  {
+    var (aggregators, _, _, output) = Generate(@"
+    [EventAggregation<Entity>(PropertyPath = nameof(Entity.ItemsList))]
+    public record ItemAppended([property: AggregationCollectionKey(""Id"")] Guid ItemId, string? Value);");
+
+    aggregators!.ShouldContain("entity.ItemsList ??= new global::System.Collections.Generic.List<global::TestApp.Item>();");
+    aggregators!.ShouldContain("global::System.Linq.Enumerable.FirstOrDefault(entity.ItemsList");
+    aggregators!.ShouldContain("target = new global::TestApp.Item();");
+    aggregators!.ShouldContain("target.Id = evt.ItemId;");
+    aggregators!.ShouldContain("entity.ItemsList.Add(target);");
+    aggregators!.ShouldContain("if (evt.Value is not null) { target.Value = evt.Value; }");
+    ShouldCompileClean(output);
+  }
+
+  [Fact]
+  public void ManualAggregatorConflict_SkipsGenerationAndReportsDiagnostic()
+  {
+    var (aggregators, _, run, output) = Generate(@"
+    [EventAggregation<Entity>]
+    public record Conflicting(string? Name);
+
+    public class ConflictingAggregator : EventAggregatorBase<Entity, Conflicting>
+    {
+      public override System.Threading.Tasks.ValueTask<Entity?> ApplyAsync(Conflicting evt, Entity entity, Papst.EventStore.IAggregatorStreamContext ctx)
+        => AsTask(entity);
+    }");
+
+    run.Diagnostics.Any(d => d.Id == "EVTSRC0003").ShouldBeTrue();
+    (aggregators is null || !aggregators.Contains("Conflicting_Entity_GeneratedAggregator")).ShouldBeTrue();
+    ShouldCompileClean(output);
+  }
+}

--- a/tests/Papst.EventStore.CodeGeneration.Tests/Papst.EventStore.CodeGeneration.Tests.csproj
+++ b/tests/Papst.EventStore.CodeGeneration.Tests/Papst.EventStore.CodeGeneration.Tests.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Papst.EventStore.CodeGeneration\Papst.EventStore.CodeGeneration.csproj" />
+    <ProjectReference Include="..\..\src\Papst.EventStore.Aggregation.EventRegistration\Papst.EventStore.Aggregation.EventRegistration.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning">

--- a/tests/Papst.EventStore.EntityFrameworkCore.Tests/IntegrationTests/AggregationIntegrationTests.cs
+++ b/tests/Papst.EventStore.EntityFrameworkCore.Tests/IntegrationTests/AggregationIntegrationTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Papst.EventStore;
+using Papst.EventStore.Aggregation;
+using Papst.EventStore.Aggregation.EventRegistration;
+using Papst.EventStore.EntityFrameworkCore;
+using Papst.EventStore.Testing.Aggregation;
+using Shouldly;
+using Xunit;
+
+namespace Papst.EventStore.EntityFrameworkCore.Tests.IntegrationTests;
+
+/// <summary>
+/// Verifies the code-generated attribute based aggregation end to end against the EntityFrameworkCore store.
+/// </summary>
+public class AggregationIntegrationTests
+{
+  [Fact]
+  public async Task GeneratedAggregation_AggregatesStreamOntoEntity()
+  {
+    var services = new ServiceCollection();
+    services.AddLogging();
+    services.AddEntityFrameworkCoreEventStore(options => options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+    services.AddRegisteredEventAggregation();
+    EventStoreEventAggregator.AddCodeGeneratedEvents(services);
+    var provider = services.BuildServiceProvider();
+
+    var store = provider.GetRequiredService<IEventStore>();
+    var aggregator = provider.GetRequiredService<IEventStreamAggregator<SampleOrder>>();
+
+    var streamId = Guid.NewGuid();
+    var stream = await store.CreateAsync(streamId, "", CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleOrderCreated("Alice"), cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleLineUpserted("SKU-1", 3), cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleLineUpserted("SKU-1", 7), cancellationToken: CancellationToken.None);
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order.ShouldNotBeNull();
+    order!.Customer.ShouldBe("Alice");
+    order.Lines.Count.ShouldBe(1);
+    order.Lines[0].Quantity.ShouldBe(7);
+  }
+}

--- a/tests/Papst.EventStore.EntityFrameworkCore.Tests/Papst.EventStore.EntityFrameworkCore.Tests.csproj
+++ b/tests/Papst.EventStore.EntityFrameworkCore.Tests/Papst.EventStore.EntityFrameworkCore.Tests.csproj
@@ -31,6 +31,11 @@
     <ProjectReference Include="..\..\src\Papst.EventStore.Aggregation.EventRegistration\Papst.EventStore.Aggregation.EventRegistration.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore.EntityFrameworkCore\Papst.EventStore.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore\Papst.EventStore.csproj" />
+    <ProjectReference Include="..\..\src\Papst.EventStore.CodeGeneration\Papst.EventStore.CodeGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\AggregationSample.cs" Link="Aggregation\AggregationSample.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Papst.EventStore.FileSystem.Tests/IntegrationTests/AggregationIntegrationTests.cs
+++ b/tests/Papst.EventStore.FileSystem.Tests/IntegrationTests/AggregationIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Papst.EventStore;
+using Papst.EventStore.Aggregation;
+using Papst.EventStore.Aggregation.EventRegistration;
+using Papst.EventStore.FileSystem;
+using Papst.EventStore.Testing.Aggregation;
+using Shouldly;
+using Xunit;
+
+namespace Papst.EventStore.FileSystem.Tests.IntegrationTests;
+
+/// <summary>
+/// Verifies the code-generated attribute based aggregation end to end against the FileSystem store.
+/// </summary>
+public class AggregationIntegrationTests : IDisposable
+{
+  private readonly string _tempPath = Path.Combine(Path.GetTempPath(), "EventStoreAggregationTests", Guid.NewGuid().ToString());
+
+  public AggregationIntegrationTests() => Directory.CreateDirectory(_tempPath);
+
+  [Fact]
+  public async Task GeneratedAggregation_AggregatesStreamOntoEntity()
+  {
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?> { ["Path"] = _tempPath })
+      .Build();
+
+    var services = new ServiceCollection();
+    services.AddLogging();
+    services.AddFileSystemEventStore(config);
+    services.AddRegisteredEventAggregation();
+    EventStoreEventAggregator.AddCodeGeneratedEvents(services);
+    var provider = services.BuildServiceProvider();
+
+    var store = provider.GetRequiredService<IEventStore>();
+    var aggregator = provider.GetRequiredService<IEventStreamAggregator<SampleOrder>>();
+
+    var streamId = Guid.NewGuid();
+    var stream = await store.CreateAsync(streamId, "", CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleOrderCreated("Alice"), cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleLineUpserted("SKU-1", 3), cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleLineUpserted("SKU-1", 7), cancellationToken: CancellationToken.None);
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order.ShouldNotBeNull();
+    order!.Customer.ShouldBe("Alice");
+    order.Lines.Count.ShouldBe(1);
+    order.Lines[0].Quantity.ShouldBe(7);
+  }
+
+  public void Dispose()
+  {
+    if (Directory.Exists(_tempPath))
+    {
+      Directory.Delete(_tempPath, recursive: true);
+    }
+  }
+}

--- a/tests/Papst.EventStore.FileSystem.Tests/Papst.EventStore.FileSystem.Tests.csproj
+++ b/tests/Papst.EventStore.FileSystem.Tests/Papst.EventStore.FileSystem.Tests.csproj
@@ -31,6 +31,11 @@
     <ProjectReference Include="..\..\src\Papst.EventStore.Aggregation.EventRegistration\Papst.EventStore.Aggregation.EventRegistration.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore.FileSystem\Papst.EventStore.FileSystem.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore\Papst.EventStore.csproj" />
+    <ProjectReference Include="..\..\src\Papst.EventStore.CodeGeneration\Papst.EventStore.CodeGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\AggregationSample.cs" Link="Aggregation\AggregationSample.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Papst.EventStore.MongoDB.Tests/IntegrationTests/AggregationIntegrationTests.cs
+++ b/tests/Papst.EventStore.MongoDB.Tests/IntegrationTests/AggregationIntegrationTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Papst.EventStore;
+using Papst.EventStore.Aggregation;
+using Papst.EventStore.Aggregation.EventRegistration;
+using Papst.EventStore.MongoDB;
+using Papst.EventStore.Testing.Aggregation;
+using Shouldly;
+using Xunit;
+
+namespace Papst.EventStore.MongoDB.Tests.IntegrationTests;
+
+/// <summary>
+/// Verifies the code-generated attribute based aggregation end to end against the MongoDB store
+/// (requires a running Docker/Podman engine for Testcontainers).
+/// </summary>
+public class AggregationIntegrationTests : IClassFixture<MongoDBIntegrationTestFixture>
+{
+  private readonly MongoDBIntegrationTestFixture _fixture;
+
+  public AggregationIntegrationTests(MongoDBIntegrationTestFixture fixture) => _fixture = fixture;
+
+  [Fact]
+  public async Task GeneratedAggregation_AggregatesStreamOntoEntity()
+  {
+    var services = new ServiceCollection();
+    services.AddLogging();
+    services.AddMongoDBEventStore(options =>
+    {
+      options.ConnectionString = _fixture.ConnectionString;
+      options.DatabaseName = MongoDBIntegrationTestFixture.DatabaseName;
+    });
+    services.AddRegisteredEventAggregation();
+    EventStoreEventAggregator.AddCodeGeneratedEvents(services);
+    var provider = services.BuildServiceProvider();
+
+    var store = provider.GetRequiredService<IEventStore>();
+    var aggregator = provider.GetRequiredService<IEventStreamAggregator<SampleOrder>>();
+
+    var streamId = Guid.NewGuid();
+    var stream = await store.CreateAsync(streamId, "TestType", CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleOrderCreated("Alice"), cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleLineUpserted("SKU-1", 3), cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleLineUpserted("SKU-1", 7), cancellationToken: CancellationToken.None);
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order.ShouldNotBeNull();
+    order!.Customer.ShouldBe("Alice");
+    order.Lines.Count.ShouldBe(1);
+    order.Lines[0].Quantity.ShouldBe(7);
+  }
+}

--- a/tests/Papst.EventStore.MongoDB.Tests/Papst.EventStore.MongoDB.Tests.csproj
+++ b/tests/Papst.EventStore.MongoDB.Tests/Papst.EventStore.MongoDB.Tests.csproj
@@ -30,12 +30,14 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\TestcontainersRuntime.cs" Link="TestcontainersRuntime.cs" />
+    <Compile Include="..\Shared\AggregationSample.cs" Link="Aggregation\AggregationSample.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Papst.EventStore.Aggregation.EventRegistration\Papst.EventStore.Aggregation.EventRegistration.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore.MongoDB\Papst.EventStore.MongoDB.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore\Papst.EventStore.csproj" />
+    <ProjectReference Include="..\..\src\Papst.EventStore.CodeGeneration\Papst.EventStore.CodeGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/tests/Papst.EventStore.Tests/Aggregation/AggregationSamples.cs
+++ b/tests/Papst.EventStore.Tests/Aggregation/AggregationSamples.cs
@@ -48,6 +48,14 @@ public record CustomerNameForced(string? CustomerName);
 [EventAggregation<OrderAggregate>(PropertyPath = nameof(OrderAggregate.ShippingAddress))]
 public record ShippingAddressSet(string? City, string? Zip);
 
+// DisplayName is remapped onto CustomerName; the same-named CustomerName is explicitly ignored (so it must not
+// overwrite the remapped value).
+[EventName(nameof(CustomerRenamed))]
+[EventAggregation<OrderAggregate>]
+public record CustomerRenamed(
+  [property: AggregationProperty(nameof(OrderAggregate.CustomerName))] string? DisplayName,
+  [property: AggregationIgnore] string? CustomerName);
+
 [EventName(nameof(LineUpserted))]
 [EventAggregation<OrderAggregate>(PropertyPath = nameof(OrderAggregate.Lines))]
 public record LineUpserted([property: AggregationDictionaryKey] string Sku, int Quantity, [property: SkipWhenNull(true)] string? Note);

--- a/tests/Papst.EventStore.Tests/Aggregation/AggregationSamples.cs
+++ b/tests/Papst.EventStore.Tests/Aggregation/AggregationSamples.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System.Collections.Generic;
+using Papst.EventStore.Aggregation.EventRegistration;
+
+namespace Papst.EventStore.Tests.Aggregation;
+
+/// <summary>
+/// Sample aggregate + events used to exercise the code-generated attribute based aggregation
+/// end to end (store agnostic). Events carry both <c>[EventName]</c> (for type resolution) and
+/// <c>[EventAggregation]</c> (for the generated aggregator).
+/// </summary>
+public class OrderAggregate : IEntity
+{
+  public ulong Version { get; set; }
+  public string? CustomerName { get; set; }
+  public OrderAddress ShippingAddress { get; set; } = new();
+  public Dictionary<string, OrderLine> Lines { get; set; } = new();
+  public List<OrderTag> Tags { get; set; } = new();
+}
+
+public class OrderAddress
+{
+  public string? City { get; set; }
+  public string? Zip { get; set; }
+}
+
+public class OrderLine
+{
+  public int Quantity { get; set; }
+  public string? Note { get; set; }
+}
+
+public class OrderTag
+{
+  public string? Id { get; set; }
+  public string? Label { get; set; }
+}
+
+[EventName(nameof(OrderCreated))]
+[EventAggregation<OrderAggregate>]
+public record OrderCreated(string? CustomerName);
+
+[EventName(nameof(CustomerNameForced))]
+[EventAggregation<OrderAggregate>(SkipNullValues = false)]
+public record CustomerNameForced(string? CustomerName);
+
+[EventName(nameof(ShippingAddressSet))]
+[EventAggregation<OrderAggregate>(PropertyPath = nameof(OrderAggregate.ShippingAddress))]
+public record ShippingAddressSet(string? City, string? Zip);
+
+[EventName(nameof(LineUpserted))]
+[EventAggregation<OrderAggregate>(PropertyPath = nameof(OrderAggregate.Lines))]
+public record LineUpserted([property: AggregationDictionaryKey] string Sku, int Quantity, [property: SkipWhenNull(true)] string? Note);
+
+[EventName(nameof(TagUpserted))]
+[EventAggregation<OrderAggregate>(PropertyPath = nameof(OrderAggregate.Tags))]
+public record TagUpserted([property: AggregationCollectionKey("Id")] string TagId, string? Label);

--- a/tests/Papst.EventStore.Tests/Aggregation/GeneratedAggregationTests.cs
+++ b/tests/Papst.EventStore.Tests/Aggregation/GeneratedAggregationTests.cs
@@ -64,6 +64,20 @@ public class GeneratedAggregationTests
   }
 
   [Fact]
+  public async Task RemapAndIgnore_WriteToRemappedTarget_AndSkipIgnored()
+  {
+    var aggregator = BuildAggregator();
+    var stream = new FakeStream();
+    stream.Append(new OrderCreated("Alice"));
+    // DisplayName -> CustomerName (remap); the ignored CustomerName field must not overwrite it.
+    stream.Append(new CustomerRenamed(DisplayName: "Bob", CustomerName: "IGNORED"));
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order!.CustomerName.ShouldBe("Bob");
+  }
+
+  [Fact]
   public async Task NestedPropertyPath_AggregatesOntoChild()
   {
     var aggregator = BuildAggregator();

--- a/tests/Papst.EventStore.Tests/Aggregation/GeneratedAggregationTests.cs
+++ b/tests/Papst.EventStore.Tests/Aggregation/GeneratedAggregationTests.cs
@@ -1,0 +1,172 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Linq;
+using Papst.EventStore.Aggregation;
+using Papst.EventStore.Aggregation.EventRegistration;
+using Papst.EventStore.Documents;
+using Shouldly;
+using Xunit;
+
+namespace Papst.EventStore.Tests.Aggregation;
+
+/// <summary>
+/// End-to-end, store-agnostic tests for the code-generated attribute based aggregation. They drive the real
+/// generated aggregators (registered via the generated <c>AddCodeGeneratedEvents</c>) through the
+/// <see cref="IEventStreamAggregator{TEntity}"/> using a hand-rolled stream.
+/// </summary>
+public class GeneratedAggregationTests
+{
+  private static IEventStreamAggregator<OrderAggregate> BuildAggregator()
+  {
+    var services = new ServiceCollection();
+    services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+    services.AddSingleton(typeof(ILogger<>), typeof(Logger<>));
+    services.AddRegisteredEventAggregation();
+    // generated extension: registers [EventName] events, the type provider and all generated aggregators
+    EventStoreEventAggregator.AddCodeGeneratedEvents(services);
+    return services.BuildServiceProvider().GetRequiredService<IEventStreamAggregator<OrderAggregate>>();
+  }
+
+  [Fact]
+  public async Task RootAggregation_MapsMatchingProperties()
+  {
+    var aggregator = BuildAggregator();
+    var stream = new FakeStream();
+    stream.Append(new OrderCreated("Alice"));
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order.ShouldNotBeNull();
+    order!.CustomerName.ShouldBe("Alice");
+  }
+
+  [Fact]
+  public async Task RootAggregation_SkipsNullByDefault_ButForcesWhenConfigured()
+  {
+    var aggregator = BuildAggregator();
+    var stream = new FakeStream();
+    stream.Append(new OrderCreated("Alice"));
+    stream.Append(new OrderCreated(null));          // skip-null default: keeps "Alice"
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+    order!.CustomerName.ShouldBe("Alice");
+
+    stream.Append(new CustomerNameForced(null));    // SkipNullValues = false: clears
+    order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+    order!.CustomerName.ShouldBeNull();
+  }
+
+  [Fact]
+  public async Task NestedPropertyPath_AggregatesOntoChild()
+  {
+    var aggregator = BuildAggregator();
+    var stream = new FakeStream();
+    stream.Append(new ShippingAddressSet("Berlin", "10115"));
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order!.ShippingAddress.City.ShouldBe("Berlin");
+    order.ShippingAddress.Zip.ShouldBe("10115");
+  }
+
+  [Fact]
+  public async Task DictionaryPropertyPath_UpsertsEntries()
+  {
+    var aggregator = BuildAggregator();
+    var stream = new FakeStream();
+    stream.Append(new LineUpserted("SKU-1", 2, "first"));
+    stream.Append(new LineUpserted("SKU-2", 5, null));
+    stream.Append(new LineUpserted("SKU-1", 9, null));  // updates existing; Note skipped (null)
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order!.Lines.Count.ShouldBe(2);
+    order.Lines["SKU-1"].Quantity.ShouldBe(9);
+    order.Lines["SKU-1"].Note.ShouldBe("first");   // preserved because SkipWhenNull(true)
+    order.Lines["SKU-2"].Quantity.ShouldBe(5);
+  }
+
+  [Fact]
+  public async Task CollectionPropertyPath_UpsertsBySearchKey()
+  {
+    var aggregator = BuildAggregator();
+    var stream = new FakeStream();
+    stream.Append(new TagUpserted("t1", "Urgent"));
+    stream.Append(new TagUpserted("t2", "Wholesale"));
+    stream.Append(new TagUpserted("t1", "Priority"));   // updates existing item
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order!.Tags.Count.ShouldBe(2);
+    order.Tags.ShouldContain(t => t.Id == "t1" && t.Label == "Priority");
+    order.Tags.ShouldContain(t => t.Id == "t2" && t.Label == "Wholesale");
+  }
+
+  private sealed class FakeStream : IEventStream
+  {
+    private readonly List<EventStreamDocument> _events = new();
+
+    public Guid StreamId { get; } = Guid.NewGuid();
+    public ulong Version => _events.Count == 0 ? 0 : _events[_events.Count - 1].Version;
+    public DateTimeOffset Created { get; } = DateTimeOffset.UtcNow;
+    public ulong? LatestSnapshotVersion => null;
+    public EventStreamMetaData MetaData { get; } = new();
+
+    public void Append<TEvent>(TEvent evt) where TEvent : notnull
+      => _events.Add(new EventStreamDocument
+      {
+        Id = Guid.NewGuid(),
+        StreamId = StreamId,
+        DocumentType = EventStreamDocumentType.Event,
+        Version = (ulong)_events.Count,
+        Time = DateTimeOffset.UtcNow,
+        Name = typeof(TEvent).Name,
+        Data = JObject.FromObject(evt),
+        DataType = typeof(TEvent).Name,
+        TargetType = nameof(OrderAggregate),
+      });
+
+    public Task<EventStreamDocument?> GetLatestSnapshot(CancellationToken cancellationToken = default)
+      => Task.FromResult<EventStreamDocument?>(null);
+
+    public Task AppendAsync<TEvent>(Guid id, TEvent evt, EventStreamMetaData? metaData = null, CancellationToken cancellationToken = default) where TEvent : notnull
+      => throw new NotSupportedException();
+
+    public Task AppendSnapshotAsync<TEntity>(Guid id, TEntity entity, EventStreamMetaData? metaData = null, CancellationToken cancellationToken = default) where TEntity : notnull
+      => throw new NotSupportedException();
+
+    public Task<IEventStoreTransactionAppender> CreateTransactionalBatchAsync()
+      => throw new NotSupportedException();
+
+    public IAsyncEnumerable<EventStreamDocument> ListAsync(ulong startVersion = 0u, CancellationToken cancellationToken = default)
+      => ListAsync(startVersion, Version, cancellationToken);
+
+    public async IAsyncEnumerable<EventStreamDocument> ListAsync(ulong startVersion, ulong endVersion, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+      foreach (var doc in _events)
+      {
+        if (doc.Version >= startVersion && doc.Version <= endVersion)
+        {
+          yield return doc;
+        }
+      }
+      await Task.CompletedTask;
+    }
+
+    public IAsyncEnumerable<EventStreamDocument> ListDescendingAsync(ulong endVersion, ulong startVersion, CancellationToken cancellationToken = default)
+      => throw new NotSupportedException();
+
+    public IAsyncEnumerable<EventStreamDocument> ListDescendingAsync(ulong endVersion, CancellationToken cancellationToken = default)
+      => throw new NotSupportedException();
+
+    public Task UpdateStreamMetaData(EventStreamMetaData metaData, CancellationToken cancellationToken = default)
+      => Task.CompletedTask;
+  }
+}

--- a/tests/Papst.EventStore.Tests/Papst.EventStore.Tests.csproj
+++ b/tests/Papst.EventStore.Tests/Papst.EventStore.Tests.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Papst.EventStore.Aggregation.EventRegistration\Papst.EventStore.Aggregation.EventRegistration.csproj" />
     <ProjectReference Include="..\..\src\Papst.EventStore\Papst.EventStore.csproj" />
+    <ProjectReference Include="..\..\src\Papst.EventStore.CodeGeneration\Papst.EventStore.CodeGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning">

--- a/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/AggregationIntegrationTests.cs
+++ b/tests/Papst.EventsStore.InMemory.Tests/IntegrationTests/AggregationIntegrationTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Papst.EventStore;
+using Papst.EventStore.Aggregation;
+using Papst.EventStore.Aggregation.EventRegistration;
+using Papst.EventStore.InMemory;
+using Papst.EventStore.Testing.Aggregation;
+using Shouldly;
+
+namespace Papst.EventsStore.InMemory.Tests.IntegrationTests;
+
+/// <summary>
+/// Verifies that the code-generated attribute based aggregation works end to end against the InMemory store,
+/// wired through the generated <c>AddCodeGeneratedEvents</c> registration.
+/// </summary>
+public class AggregationIntegrationTests
+{
+  [Fact]
+  public async Task GeneratedAggregation_AggregatesStreamOntoEntity()
+  {
+    var services = new ServiceCollection();
+    services.AddLogging();
+    services.AddInMemoryEventStore();
+    services.AddRegisteredEventAggregation();
+    EventStoreEventAggregator.AddCodeGeneratedEvents(services);
+    var provider = services.BuildServiceProvider();
+
+    var store = provider.GetRequiredService<IEventStore>();
+    var aggregator = provider.GetRequiredService<IEventStreamAggregator<SampleOrder>>();
+
+    var streamId = Guid.NewGuid();
+    var stream = await store.CreateAsync(streamId, "", CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleOrderCreated("Alice"), cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleLineUpserted("SKU-1", 3), cancellationToken: CancellationToken.None);
+    await stream.AppendAsync(Guid.NewGuid(), new SampleLineUpserted("SKU-1", 7), cancellationToken: CancellationToken.None);
+
+    var order = await aggregator.AggregateAsync(stream, CancellationToken.None);
+
+    order.ShouldNotBeNull();
+    order!.Customer.ShouldBe("Alice");
+    order.Lines.Count.ShouldBe(1);
+    order.Lines[0].Sku.ShouldBe("SKU-1");
+    order.Lines[0].Quantity.ShouldBe(7);
+  }
+}

--- a/tests/Papst.EventsStore.InMemory.Tests/Papst.EventsStore.InMemory.Tests.csproj
+++ b/tests/Papst.EventsStore.InMemory.Tests/Papst.EventsStore.InMemory.Tests.csproj
@@ -33,6 +33,11 @@
     <ItemGroup>
       <ProjectReference Include="..\..\src\Papst.EventStore.Aggregation.EventRegistration\Papst.EventStore.Aggregation.EventRegistration.csproj" />
       <ProjectReference Include="..\..\src\Papst.EventStore.InMemory\Papst.EventStore.InMemory.csproj" />
+      <ProjectReference Include="..\..\src\Papst.EventStore.CodeGeneration\Papst.EventStore.CodeGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\Shared\AggregationSample.cs" Link="Aggregation\AggregationSample.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Shared/AggregationSample.cs
+++ b/tests/Shared/AggregationSample.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System.Collections.Generic;
+using Papst.EventStore;
+using Papst.EventStore.Aggregation.EventRegistration;
+
+namespace Papst.EventStore.Testing.Aggregation;
+
+/// <summary>
+/// Shared sample aggregate + code-generated-aggregation events, link-included into each store test project so
+/// the generated <c>AddCodeGeneratedEvents</c> can be exercised against a real store implementation.
+/// </summary>
+public class SampleOrder : IEntity
+{
+  public ulong Version { get; set; }
+  public string? Customer { get; set; }
+  public List<SampleLine> Lines { get; set; } = new();
+}
+
+public class SampleLine
+{
+  public string? Sku { get; set; }
+  public int Quantity { get; set; }
+}
+
+[EventName(nameof(SampleOrderCreated))]
+[EventAggregation<SampleOrder>]
+public record SampleOrderCreated(string? Customer);
+
+[EventName(nameof(SampleLineUpserted))]
+[EventAggregation<SampleOrder>(PropertyPath = nameof(SampleOrder.Lines))]
+public record SampleLineUpserted([property: AggregationCollectionKey("Sku")] string Sku, int Quantity);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.4",
+  "version": "7.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main"
   ],


### PR DESCRIPTION
## Summary

Adds an **opt-in, code-generated** aggregation path that works **in parallel** with the existing hand-written aggregators. Annotating an event with `[EventAggregation<TEntity>]` makes the incremental source generator emit an `EventAggregatorBase<TEntity, TEvent>` (into a separate `EventAggregators.g.cs`) and register it via the existing `AddCodeGeneratedEvents()`.

### New attributes (`Papst.EventStore.Aggregation.EventRegistration`)
- `EventAggregation<TEntity>` — `PropertyPath`, `SkipNullValues`
- `SkipWhenNull(bool)` — per-property override of `SkipNullValues`
- `AggregationDictionaryKey` / `AggregationCollectionKey("Id")` — mark the key for dictionary/collection upserts

### Behaviour
- Event properties are mapped onto the entity **by name**.
- `PropertyPath` targets a nested object (intermediate `null` links are instantiated), a `Dictionary<,>` or a collection (**upsert** semantics).
- Null handling: global `SkipNullValues` (default `true`) with per-property `[SkipWhenNull]` override.
- If a hand-written aggregator already exists for the same `(entity, event)` pair, generation is **skipped** and reported as `EVTSRC0003` — the two approaches never double-register.
- Generator hardened against **nested** event/aggregator types (uses each type's own base list instead of recursive descendants), which previously crashed discovery.

### Sample
`OrderShippedEvent` in `samples/SampleInMemoryAspNetApi` uses the new method (sets `Status`, adds tracking code, pickup date and estimated arrival) via a new `POST /orders/{id}/ship` endpoint — no hand-written aggregator.

### Docs & versioning
- README: new "Attribute-based Event Aggregation" section + `V 7.0` changelog entry.
- `version.json` bumped to **7.0**; `Papst.EventStore` package range → `[7.0.0,8.0)`.

## Testing
Non-container suites pass locally: **core 61, generator 28, InMemory 20, FileSystem 9, EFCore 9** (127 total, 0 failed). MongoDB/Cosmos integration tests are wired (analyzer + shared sample + runtime test) but require a working container engine — they could not run on this host (Testcontainers/Podman container-lifecycle failure affecting all Mongo tests, pre-existing) and are left for CI.