### PR TITLE
ci: fix Skip-CI title matching and NuGet token exchange User-Agent

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -135,8 +135,8 @@ class Build : FalloutBuild
     bool? _skipCiRequested;
 
     /// <summary>
-    /// True when the merged PR title contains "skip ci" (case-insensitive). Mirrors the old
-    /// <c>check-skip</c> job: publishing is suppressed, build and test still run.
+    /// True when the merged PR title contains "skip ci" or "skip-ci" (case-insensitive). Mirrors
+    /// the old <c>check-skip</c> job: publishing is suppressed, build and test still run.
     /// </summary>
     bool SkipCiRequested => _skipCiRequested ??= ComputeSkipCiRequested();
 
@@ -170,7 +170,7 @@ class Build : FalloutBuild
                 .Select(pr => pr.TryGetProperty("title", out JsonElement t) ? t.GetString() ?? string.Empty : string.Empty)
                 .ToList();
 
-            bool skip = titles.Any(t => t.Contains("skip ci", StringComparison.OrdinalIgnoreCase));
+            bool skip = titles.Any(t => t.Replace('-', ' ').Contains("skip ci", StringComparison.OrdinalIgnoreCase));
             Log.Information("Associated PR titles: [{Titles}] -> SkipCI={Skip}", string.Join(", ", titles), skip);
             return skip;
         }
@@ -339,6 +339,7 @@ class Build : FalloutBuild
         }
 
         using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Papst.EventStore-Build", "1.0"));
 
         // 1. Ask GitHub for an OIDC token scoped to nuget.org.
         using var oidcRequest = new HttpRequestMessage(
@@ -373,6 +374,7 @@ class Build : FalloutBuild
         TimeSpan timeout = TimeSpan.FromMinutes(15);
         TimeSpan interval = TimeSpan.FromSeconds(15);
         using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Papst.EventStore-Build", "1.0"));
 
         foreach (string packageId in packageIds)
         {


### PR DESCRIPTION
## Summary
- Skip-CI detection (`build/Build.cs`) only matched the spaced `"skip ci"` substring, so hyphenated PR titles like `[SKIP-CI] ...` never suppressed NuGet publish/release. It now normalizes hyphens to spaces before matching, so both `"skip ci"` and `"skip-ci"` (any casing) trip the gate.
- Both `HttpClient` instances used for nuget.org calls (`AcquireNuGetApiKeyAsync`'s Trusted Publishing token exchange, and `WaitForPackagesAsync`'s availability poll) sent no `User-Agent` header. nuget.org rejects such requests with `400: {"error":"A User-Agent header is required."}`, which is exactly what broke the `PublishContracts` job in [this run](https://github.com/PapstIO/Papst.EventStore/actions/runs/32165018974/job/95802479641). Both now set the same `User-Agent` already used in `CreateGitHubClient()`.

## Test plan
- [x] `dotnet build build/_build.csproj` succeeds with 0 errors/warnings
- [x] Manually verified the new match expression against `"[SKIP-CI] ..."`, `"skip ci: ..."`, `"Skip-CI"` (all match) and `"Add skipping tests"` (does not match)
- [ ] Confirm on the next push to `main` that a `[SKIP-CI]`-titled PR merge produces `SkipCI=True` in the build log and that `PublishContracts` no longer fails on the token exchange